### PR TITLE
[OP][Dist] Group ops

### DIFF
--- a/python/raf/_tvm_op/transform.py
+++ b/python/raf/_tvm_op/transform.py
@@ -420,13 +420,15 @@ _reg.register_injective_schedule("raf.op.tvm.embedding_dx")
 
 _reg.register_strategy("raf.op.tvm.cumsum", strategy.cumsum_strategy)
 
+
 @register_compute("raf.op.tvm.group_cast")
 def group_cast_compute(attrs, inputs, output_type):
     tensor_list = inputs
-    dtype = attrs.dtype 
+    dtype = attrs.dtype
     out = []
     for item in tensor_list:
         out.append(_topi.cast(item, dtype))
     return out
+
 
 _reg.register_injective_schedule("raf.op.tvm.group_cast")

--- a/python/raf/_tvm_op/transform.py
+++ b/python/raf/_tvm_op/transform.py
@@ -419,3 +419,14 @@ def embedding_dx_compute(attrs, inputs, output_type):
 _reg.register_injective_schedule("raf.op.tvm.embedding_dx")
 
 _reg.register_strategy("raf.op.tvm.cumsum", strategy.cumsum_strategy)
+
+@register_compute("raf.op.tvm.group_cast")
+def group_cast_compute(attrs, inputs, output_type):
+    tensor_list = inputs
+    dtype = attrs.dtype 
+    out = []
+    for item in tensor_list:
+        out.append(_topi.cast(item, dtype))
+    return out
+
+_reg.register_injective_schedule("raf.op.tvm.group_cast")

--- a/python/raf/distributed/__init__.py
+++ b/python/raf/distributed/__init__.py
@@ -3,5 +3,15 @@
 
 """Utils for distributed training, e.g., collective communication operators."""
 from raf._ffi.distributed import RemoveCommunicator
-from .op import allreduce, allgather, reduce, reduce_scatter, broadcast, send, recv, group_allgather, group_reduce_scatter
+from .op import (
+    allreduce,
+    allgather,
+    reduce,
+    reduce_scatter,
+    broadcast,
+    send,
+    recv,
+    group_allgather,
+    group_reduce_scatter,
+)
 from .context import DistContext, get_context

--- a/python/raf/distributed/__init__.py
+++ b/python/raf/distributed/__init__.py
@@ -3,5 +3,5 @@
 
 """Utils for distributed training, e.g., collective communication operators."""
 from raf._ffi.distributed import RemoveCommunicator
-from .op import allreduce, allgather, reduce, reduce_scatter, broadcast, send, recv
+from .op import allreduce, allgather, reduce, reduce_scatter, broadcast, send, recv, group_allgather, group_reduce_scatter
 from .context import DistContext, get_context

--- a/python/raf/distributed/op.py
+++ b/python/raf/distributed/op.py
@@ -91,11 +91,11 @@ def group_allgather(tensor_list, axis, out):
     Parameters
     ----------
     tensor_list: List[Tensor]
-        A list of tensors to perform allgather 
+        A list of tensors to perform allgather
     axis: int
         The axis over which concatenation is to be performed
     out: List[Tensor]
-        The ouptut of the allgather for each tensor 
+        The ouptut of the allgather for each tensor
     Returns
     -------
     ret: Tensor | [Tensor]

--- a/python/raf/distributed/op.py
+++ b/python/raf/distributed/op.py
@@ -85,6 +85,25 @@ def allgather(x, axis, rank_list=None):
     return x
 
 
+def group_allgather(tensor_list, axis, out):
+    """It performs allgather on each tensor in the tensor list.
+
+    Parameters
+    ----------
+    tensor_list: List[Tensor]
+        A list of tensors to perform allgather 
+    axis: int
+        The axis over which concatenation is to be performed
+    out: List[Tensor]
+        The ouptut of the allgather for each tensor 
+    Returns
+    -------
+    ret: Tensor | [Tensor]
+        Concatenation results of each tensor
+    """
+    return sym._group_allgather(tensor_list, axis, out)
+
+
 def reduce(x, root, computation="sum"):
     """Performs reduce operation. Collect data to root rank
 
@@ -125,6 +144,25 @@ def reduce_scatter(x, computation="sum"):
         where rank represents rank number of the current process
     """
     return sym._reduce_scatter(x, computation)
+
+
+def group_reduce_scatter(tensor_list, computation="sum"):
+    """Performs reduction then scatter for each tensor in the list
+
+    Parameters
+    ----------
+    tensor_list: List[Tensor]
+        A list of tensors to perform reduce scatter
+    computation: string
+        The reduction operation, default is sum
+
+    Returns
+    -------
+    ret: List[Tensor]
+        reduction result of each tensor[rank] over all replicas,
+        where rank represents rank number of the current process
+    """
+    return sym._group_reduce_scatter(tensor_list, computation)
 
 
 def broadcast(x, root):

--- a/scripts/src_codegen/def_op.py
+++ b/scripts/src_codegen/def_op.py
@@ -163,6 +163,7 @@ OPS = [
     Op(name="defuse_tensor", schema_name="defuse_tensor"),
     Op(name="cast", schema_name="cast"),
     Op(name="cast_like", schema_name="binary_like"),
+    Op(name="group_cast", schema_name="group_cast"),
     Op(name="gather", schema_name="gather"),
     Op(name="gather_dx", schema_name="gather_dx"),
     Op(name="gather_nd", schema_name="gather_nd"),
@@ -197,8 +198,10 @@ OPS = [
     # frontend and the wrapper ops are defined in python/raf/distributed/op.py
     Op(name="_allreduce", schema_name="allreduce"),
     Op(name="_allgather", schema_name="allgather"),
+    Op(name="_group_allgather", schema_name="group_allgather"),
     Op(name="_reduce", schema_name="comm_reduce"),
     Op(name="_reduce_scatter", schema_name="reduce_scatter"),
+    Op(name="_group_reduce_scatter", schema_name="group_reduce_scatter"),
     Op(name="_broadcast", schema_name="broadcast"),
     Op(name="_send", schema_name="send"),
     Op(name="_recv", schema_name="recv"),

--- a/scripts/src_codegen/def_schema.py
+++ b/scripts/src_codegen/def_schema.py
@@ -699,16 +699,26 @@ SCHEMAS = {
         Arg(name="rank_list", cxx_type="value::Value", cxx_default="nullptr"),
     ],
     "communication.h::group_allgather": [
-        Arg(name="tensor_list", cxx_type="std::vector<value::BaseTensorValue>", cxx_normalizer="TensorTuple"),
+        Arg(
+            name="tensor_list",
+            cxx_type="std::vector<value::BaseTensorValue>",
+            cxx_normalizer="TensorTuple",
+        ),
         Arg(name="axis", cxx_type="int"),
-        Arg(name="out", cxx_type="std::vector<value::BaseTensorValue>", cxx_normalizer="TensorTuple"),
-    ], 
+        Arg(
+            name="out", cxx_type="std::vector<value::BaseTensorValue>", cxx_normalizer="TensorTuple"
+        ),
+    ],
     "communication.h::reduce_scatter": [
         Arg(name="x", cxx_type="std::vector<value::BaseTensorValue>", cxx_normalizer="TensorTuple"),
         Arg(name="computation", cxx_type="std::string", cxx_default='"sum"', py_default='"sum"'),
     ],
-       "communication.h::group_reduce_scatter": [
-        Arg(name="tensor_list", cxx_type="std::vector<value::BaseTensorValue>", cxx_normalizer="TensorTuple"),
+    "communication.h::group_reduce_scatter": [
+        Arg(
+            name="tensor_list",
+            cxx_type="std::vector<value::BaseTensorValue>",
+            cxx_normalizer="TensorTuple",
+        ),
         Arg(name="computation", cxx_type="std::string", cxx_default='"sum"', py_default='"sum"'),
     ],
     "communication.h::broadcast": [

--- a/scripts/src_codegen/def_schema.py
+++ b/scripts/src_codegen/def_schema.py
@@ -526,6 +526,14 @@ SCHEMAS = {
         Arg(name="data", cxx_type="value::BaseTensorValue"),
         Arg(name="dtype", cxx_type="std::string"),
     ],
+    "transform.h::group_cast": [
+        Arg(
+            name="tensor_list",
+            cxx_type="std::vector<value::BaseTensorValue>",
+            cxx_normalizer="TensorTuple",
+        ),
+        Arg(name="dtype", cxx_type="std::string"),
+    ],
     "transform.h::strided_slice": [
         Arg(name="x", cxx_type="value::BaseTensorValue"),
         Arg(name="begin", cxx_type="value::Value"),
@@ -690,8 +698,17 @@ SCHEMAS = {
         Arg(name="axis", cxx_type="int"),
         Arg(name="rank_list", cxx_type="value::Value", cxx_default="nullptr"),
     ],
+    "communication.h::group_allgather": [
+        Arg(name="tensor_list", cxx_type="std::vector<value::BaseTensorValue>", cxx_normalizer="TensorTuple"),
+        Arg(name="axis", cxx_type="int"),
+        Arg(name="out", cxx_type="std::vector<value::BaseTensorValue>", cxx_normalizer="TensorTuple"),
+    ], 
     "communication.h::reduce_scatter": [
         Arg(name="x", cxx_type="std::vector<value::BaseTensorValue>", cxx_normalizer="TensorTuple"),
+        Arg(name="computation", cxx_type="std::string", cxx_default='"sum"', py_default='"sum"'),
+    ],
+       "communication.h::group_reduce_scatter": [
+        Arg(name="tensor_list", cxx_type="std::vector<value::BaseTensorValue>", cxx_normalizer="TensorTuple"),
         Arg(name="computation", cxx_type="std::string", cxx_default='"sum"', py_default='"sum"'),
     ],
     "communication.h::broadcast": [

--- a/src/op/declare/collective_comm.cc
+++ b/src/op/declare/collective_comm.cc
@@ -95,13 +95,12 @@ RAF_OP_DECLARE("raf.op._allgather", AllGather)
     .set_attr<TOpPattern>("TOpPattern", kOpaque)
     .set_attr<TRAFCollective>("TRAFCollective", true);
 
-
 void GroupAllGather(const CallValues& call) {
   const auto* args = call->args.as<GroupAllgatherArgs>();
   CHECK(args != nullptr);
   std::vector<TensorValue> ret;
   const DLTensor* first_tensor = args->tensor_list[0];
-  for (int i=0; i< args->tensor_list.size(); ++i){
+  for (int i = 0; i < args->tensor_list.size(); ++i) {
     const DLTensor* x = args->tensor_list[i];
     std::vector<int64_t> shape(x->shape, x->shape + x->ndim);
     shape[args->axis] *= Communicator::Get()->size;
@@ -117,7 +116,6 @@ RAF_OP_DECLARE("raf.op._group_allgather", GroupAllGather)
     .set_attr<TOpPattern>("TOpPattern", kOpaque)
     .set_attr<TRAFCollective>("TRAFCollective", true)
     .set_attr<TRAFInplaceUpdate>("TRAFInplaceUpdate", {{2, 0}});
-
 
 void ReduceScatter(const CallValues& call) {
   const auto* args = call->args.as<ReduceScatterArgs>();
@@ -160,7 +158,7 @@ void GroupReduceScatter(const CallValues& call) {
   call->out = TupleValue::make(ir::Array<Value>(ret.begin(), ret.end()));
 }
 
-RAF_OP_DECLARE("mnm.op._group_reduce_scatter", GroupReduceScatter)
+RAF_OP_DECLARE("raf.op._group_reduce_scatter", GroupReduceScatter)
     .set_attr<TOpPattern>("TOpPattern", kOpaque)
     .set_attr<TRAFCollective>("TRAFCollective", true);
 

--- a/src/op/declare/collective_comm.cc
+++ b/src/op/declare/collective_comm.cc
@@ -95,6 +95,30 @@ RAF_OP_DECLARE("raf.op._allgather", AllGather)
     .set_attr<TOpPattern>("TOpPattern", kOpaque)
     .set_attr<TRAFCollective>("TRAFCollective", true);
 
+
+void GroupAllGather(const CallValues& call) {
+  const auto* args = call->args.as<GroupAllgatherArgs>();
+  CHECK(args != nullptr);
+  std::vector<TensorValue> ret;
+  const DLTensor* first_tensor = args->tensor_list[0];
+  for (int i=0; i< args->tensor_list.size(); ++i){
+    const DLTensor* x = args->tensor_list[i];
+    std::vector<int64_t> shape(x->shape, x->shape + x->ndim);
+    shape[args->axis] *= Communicator::Get()->size;
+    ret.push_back(TensorValue::Assemble(/*dev=*/x->device,
+                                        /*dtype=*/x->dtype,
+                                        /*shape=*/shape));
+  }
+  call->device = first_tensor->device;
+  call->out = TupleValue::make(ir::Array<Value>(ret.begin(), ret.end()));
+}
+
+RAF_OP_DECLARE("raf.op._group_allgather", GroupAllGather)
+    .set_attr<TOpPattern>("TOpPattern", kOpaque)
+    .set_attr<TRAFCollective>("TRAFCollective", true)
+    .set_attr<TRAFInplaceUpdate>("TRAFInplaceUpdate", {{2, 0}});
+
+
 void ReduceScatter(const CallValues& call) {
   const auto* args = call->args.as<ReduceScatterArgs>();
   CHECK(args != nullptr);
@@ -113,6 +137,30 @@ void ReduceScatter(const CallValues& call) {
 }
 
 RAF_OP_DECLARE("raf.op._reduce_scatter", ReduceScatter)
+    .set_attr<TOpPattern>("TOpPattern", kOpaque)
+    .set_attr<TRAFCollective>("TRAFCollective", true);
+
+void GroupReduceScatter(const CallValues& call) {
+  const auto* args = call->args.as<GroupReduceScatterArgs>();
+  CHECK(args != nullptr);
+  std::vector<BaseTensorValue> tvs = args->tensor_list;
+  const DLTensor* first_tensor = tvs[0];
+  std::vector<TensorValue> ret;
+  int size = Communicator::Get()->size;
+  for (const auto& tv : tvs) {
+    const DLTensor* x = tv;
+    std::vector<int64_t> shape(x->shape, x->shape + x->ndim);
+    CHECK(shape[0] % size == 0);
+    shape[0] = shape[0] / size;
+    ret.push_back(TensorValue::Assemble(/*dev=*/x->device,
+                                        /*dtype=*/x->dtype,
+                                        /*shape=*/shape));
+  }
+  call->device = first_tensor->device;
+  call->out = TupleValue::make(ir::Array<Value>(ret.begin(), ret.end()));
+}
+
+RAF_OP_DECLARE("mnm.op._group_reduce_scatter", GroupReduceScatter)
     .set_attr<TOpPattern>("TOpPattern", kOpaque)
     .set_attr<TRAFCollective>("TRAFCollective", true);
 

--- a/src/op/declare/transform.cc
+++ b/src/op/declare/transform.cc
@@ -871,6 +871,25 @@ RAF_OP_DECLARE("raf.op.cast_like", [](const CallValues& call) {
   call->device = x->device;
 });
 
+RAF_OP_DECLARE("raf.op.group_cast", [](const CallValues& call) {
+  const auto* args = call->args.as<GroupCastArgs>();
+  CHECK(args != nullptr);
+   
+  const DLTensor* first_tensor = args->tensor_list[0];
+
+  std::vector<TensorValue> ret;
+  std::string dtype = args->dtype;
+  for (int i =0; i< args->tensor_list.size(); ++i){
+    DLTensor* x = args->tensor_list[i];
+    std::vector<int64_t> oshape(x->shape, x->shape + x->ndim);
+    ret.push_back(TensorValue::Assemble(/*dev=*/x->device,
+                                        /*dtype=*/String2DLDataType(dtype),
+                                        /*shape=*/oshape));
+  } 
+  call->out = TupleValue::make(ir::Array<Value>(ret.begin(), ret.end()));
+  call->device = first_tensor->device;
+});
+
 RAF_OP_DECLARE("raf.op.gather", [](const CallValues& call) {
   const auto* args = call->args.as<GatherArgs>();
   CHECK(args != nullptr);

--- a/src/op/declare/transform.cc
+++ b/src/op/declare/transform.cc
@@ -874,18 +874,18 @@ RAF_OP_DECLARE("raf.op.cast_like", [](const CallValues& call) {
 RAF_OP_DECLARE("raf.op.group_cast", [](const CallValues& call) {
   const auto* args = call->args.as<GroupCastArgs>();
   CHECK(args != nullptr);
-   
+
   const DLTensor* first_tensor = args->tensor_list[0];
 
   std::vector<TensorValue> ret;
   std::string dtype = args->dtype;
-  for (int i =0; i< args->tensor_list.size(); ++i){
+  for (int i = 0; i < args->tensor_list.size(); ++i) {
     DLTensor* x = args->tensor_list[i];
     std::vector<int64_t> oshape(x->shape, x->shape + x->ndim);
     ret.push_back(TensorValue::Assemble(/*dev=*/x->device,
                                         /*dtype=*/String2DLDataType(dtype),
                                         /*shape=*/oshape));
-  } 
+  }
   call->out = TupleValue::make(ir::Array<Value>(ret.begin(), ret.end()));
   call->device = first_tensor->device;
 });

--- a/src/op/dialect/nccl/nccl.cc
+++ b/src/op/dialect/nccl/nccl.cc
@@ -395,7 +395,6 @@ class NCCLGroupReduceScatter : public raf::op::OpEnv {
     auto tv = Downcast<value::TupleValue>(inputs[0]);
     auto out = Downcast<value::TupleValue>(output);
     size_t offset = 0;
-    // DLTensor* out = output;
     DType dtype;
     NCCL_CALL(ncclGroupStart());
     for (int ti = 0; ti < tv->fields.size(); ++ti) {

--- a/src/op/dialect/nccl/nccl.cc
+++ b/src/op/dialect/nccl/nccl.cc
@@ -192,6 +192,62 @@ class NCCLAllGather : public raf::op::OpEnv {
 RAF_REGISTER_DIALECT_OP(nccl, _allgather, 10);
 RAF_OP_ENV_MAKER("raf.op.nccl._allgather", NCCLAllGather::make);
 
+class NCCLGroupAllGather : public raf::op::OpEnv {
+  void* stream;
+  void* communicator;
+  explicit NCCLGroupAllGather(const CallValues& cv) {
+    auto op = ir::Op::Get("raf.op._group_allgather");
+    auto fschema_index = ir::Op::GetAttrMap<op::FRAFSchemaFieldIndex>("FRAFSchemaFieldIndex");
+    this->arg_indices = {fschema_index[op]("tensor_list")};
+    RequestStream(&stream, cv->device, StreamTagEnum::CudaCommunicate());
+    RequestDistributed(&communicator);
+  }
+
+ public:
+  ~NCCLGroupAllGather() {
+  }
+
+  std::string name() const override {
+    return TruncateName(GetUniqueName("raf.op.nccl._group_allgather"));
+  }
+
+  void Execute(const CallValues& cv) override {
+    auto args = cv->args.as<raf::op::schema::GroupAllgatherArgs>();
+    Execute(
+        {TupleValue::make(ir::Array<Value>(args->tensor_list.begin(), args->tensor_list.end()))},
+        cv->out);
+  }
+
+  void Execute(const std::vector<value::Value>& inputs, value::Value output) override {
+
+    auto comm_ptr = reinterpret_cast<NCCLCommunicatorObj*>(communicator);
+    ncclComm_t nccl_comm = comm_ptr->nccl_comm;  
+	value::TupleValue out = tvm::runtime::Downcast<value::TupleValue>(output);
+    auto tv = Downcast<value::TupleValue>(inputs[0]);
+
+    NCCL_CALL(ncclGroupStart());
+    for (int ti = 0; ti < tv->fields.size(); ++ti) {
+      DLTensor* it = tv->fields[ti];
+      DLTensor* ot = out->fields[ti];
+      int64_t size = 1;
+      for (int i = 0; i < it->ndim; ++i) {
+        size *= it->shape[i];
+      }
+      NCCL_CALL(ncclAllGather(it->data, ot->data, size, DType(it->dtype), nccl_comm,
+                              (cudaStream_t)stream));
+      }
+      NCCL_CALL(ncclGroupEnd());
+  }
+
+  static OpEnv* make(const CallValues& cv) {
+    return new NCCLGroupAllGather(cv);
+  }
+};
+
+RAF_REGISTER_DIALECT_OP(nccl, _group_allgather, 10);
+RAF_OP_ENV_MAKER("raf.op.nccl._group_allgather", NCCLGroupAllGather::make);
+
+
 class NCCLReduceScatter : public raf::op::OpEnv {
   void* stream;
   void* communicator;
@@ -277,6 +333,89 @@ class NCCLReduceScatter : public raf::op::OpEnv {
 
 RAF_REGISTER_DIALECT_OP(nccl, _reduce_scatter, 10);
 RAF_OP_ENV_MAKER("raf.op.nccl._reduce_scatter", NCCLReduceScatter::make);
+
+class NCCLGroupReduceScatter : public raf::op::OpEnv {
+  void* stream;
+  void* communicator;
+  std::vector<size_t> sizes;
+  ncclRedOp_t compute;
+
+  explicit NCCLGroupReduceScatter(const CallValues& cv) {
+    
+    auto op = ir::Op::Get("raf.op._group_reduce_scatter");
+    auto fschema_index = ir::Op::GetAttrMap<op::FRAFSchemaFieldIndex>("FRAFSchemaFieldIndex");
+    this->arg_indices = {fschema_index[op]("tensor_list")};
+    RequestStream(&stream, cv->device, StreamTagEnum::CudaCommunicate());
+    RequestDistributed(&communicator);
+    auto args = cv->args.as<raf::op::schema::GroupReduceScatterArgs>();
+    if (args->computation.compare("sum") == 0) {
+      compute = ncclSum;
+    } else if (args->computation.compare("prod") == 0) {
+      compute = ncclProd;
+    } else if (args->computation.compare("min") == 0) {
+      compute = ncclMin;
+    } else if (args->computation.compare("max") == 0) {
+      compute = ncclMax;
+    } else if (args->computation.compare("avg") == 0) {
+#if NCCL_VERSION_CODE >= 21000
+      compute = ncclAvg;
+#else
+      LOG(FATAL) << "ReduceScatter with avg is not supported in NCCL < 2.10";
+#endif
+    } else {
+      LOG(FATAL) << "Invalid computation " << args->computation;
+    }
+
+    auto out = Downcast<value::TupleValue>(cv->out);
+    for (auto tv : out->fields) {
+      const DLTensor* ot = tv;
+      size_t size = 1;
+      for (int i = 0; i < ot->ndim; ++i) {
+        size *= ot->shape[i];
+      }
+      sizes.push_back(size);
+    }
+  }
+
+ public:
+  ~NCCLGroupReduceScatter() {
+  }
+
+  std::string name() const override {
+    return TruncateName(GetUniqueName("raf.op.nccl._group_reduce_scatter"));
+  }
+
+  void Execute(const CallValues& cv) override {
+    auto args = cv->args.as<raf::op::schema::GroupReduceScatterArgs>();
+    Execute({TupleValue::make(ir::Array<Value>(args->tensor_list.begin(), args->tensor_list.end()))}, cv->out);
+  }
+
+  void Execute(const std::vector<value::Value>& inputs, value::Value output) override {
+    auto comm_ptr = reinterpret_cast<NCCLCommunicatorObj*>(communicator);
+    ncclComm_t nccl_comm = comm_ptr->nccl_comm;
+	auto tv = Downcast<value::TupleValue>(inputs[0]);
+    auto out = Downcast<value::TupleValue>(output);
+    size_t offset = 0;
+    //DLTensor* out = output;
+    DType dtype;
+    NCCL_CALL(ncclGroupStart());
+    for (int ti = 0; ti < tv->fields.size(); ++ti) {
+      DLTensor* x = tv->fields[ti];
+      DLTensor* ot= out->fields[ti];
+      dtype = x->dtype;
+      NCCL_CALL(ncclReduceScatter(x->data, ot->data, sizes[ti], dtype, compute, nccl_comm,
+                                  (cudaStream_t)stream));
+    }
+    NCCL_CALL(ncclGroupEnd());
+  }
+
+  static OpEnv* make(const CallValues& cv) {
+    return new NCCLGroupReduceScatter(cv);
+  }
+};
+
+RAF_REGISTER_DIALECT_OP(nccl, _group_reduce_scatter, 10);
+RAF_OP_ENV_MAKER("raf.op.nccl._group_reduce_scatter", NCCLGroupReduceScatter::make);
 
 class NCCLBroadcast : public raf::op::OpEnv {
   void* stream;

--- a/src/op/dialect/tvm/transform.cc
+++ b/src/op/dialect/tvm/transform.cc
@@ -644,7 +644,7 @@ RAF_TVM(cast_like, CastLike, BinaryLikeArgs, BinaryLikeSchema2Args, BinaryLikeSc
 
 std::vector<Value> GroupCastSchema2Args(const GroupCastArgs* args) {
   std::vector<Value> ret;
-  for (auto i: args->tensor_list){
+  for (auto i : args->tensor_list) {
     ret.push_back(i);
   }
   return ret;
@@ -660,7 +660,8 @@ Attrs GroupCastSchema2Attrs(const GroupCastArgs* args) {
   return Attrs(attrs);
 }
 
-HashKey GroupCastHasher(const std::vector<Type>& param_types, const Type& y_type, const GroupCastArgs* args) {
+HashKey GroupCastHasher(const std::vector<Type>& param_types, const Type& y_type,
+                        const GroupCastArgs* args) {
   HashKey key = GenericHasher<nullptr_t>(param_types, y_type, nullptr);
   key << ir::String2DLDataType(args->dtype);
   return key;

--- a/src/op/dialect/tvm/transform.cc
+++ b/src/op/dialect/tvm/transform.cc
@@ -642,6 +642,33 @@ RAF_TVM(cast, Cast, CastArgs, CastSchema2Args, CastSchemaArgNames, CastSchema2At
 RAF_TVM(cast_like, CastLike, BinaryLikeArgs, BinaryLikeSchema2Args, BinaryLikeSchemaArgNames,
         GenericAttrs, GenericHasher, kElemWise);
 
+std::vector<Value> GroupCastSchema2Args(const GroupCastArgs* args) {
+  std::vector<Value> ret;
+  for (auto i: args->tensor_list){
+    ret.push_back(i);
+  }
+  return ret;
+}
+
+std::vector<std::string> GroupCastSchemaArgNames(const op::CallValues& call) {
+  return {"tensor_list"};
+}
+
+Attrs GroupCastSchema2Attrs(const GroupCastArgs* args) {
+  auto attrs = make_object<CastAttrs>();
+  attrs->dtype = DataType(ir::String2DLDataType(args->dtype));
+  return Attrs(attrs);
+}
+
+HashKey GroupCastHasher(const std::vector<Type>& param_types, const Type& y_type, const GroupCastArgs* args) {
+  HashKey key = GenericHasher<nullptr_t>(param_types, y_type, nullptr);
+  key << ir::String2DLDataType(args->dtype);
+  return key;
+}
+
+RAF_TVM(group_cast, GroupCast, GroupCastArgs, GroupCastSchema2Args, GroupCastSchemaArgNames,
+        GroupCastSchema2Attrs, GroupCastHasher, kElemWise);
+
 std::vector<Value> GatherSchema2Args(const GatherArgs* args) {
   return {args->data, args->indices};
 }

--- a/src/op/ty/collective_comm.cc
+++ b/src/op/ty/collective_comm.cc
@@ -56,6 +56,28 @@ Type ReduceScatterInfer(const CallValues& value) {
 
 RAF_OP_TYPE("raf.op._reduce_scatter", "NCCLReduceScatter", ReduceScatterInfer);
 
+Type GroupReduceScatterInfer(const CallValues& value) {
+  const auto* args = value->args.as<GroupReduceScatterArgs>();
+  CHECK(args != nullptr);
+  int size =Communicator::Get()->size;
+  Array<Type> ret;
+  for (const auto& tv: args->tensor_list)
+  {
+    const auto& ty = GetType(tv);
+    auto tpn = ty.as<TensorTypeNode>();
+    auto shape = tpn->shape;
+    auto old_size = shape[0].as<IntImmNode>()->value;
+    CHECK(old_size % size == 0);
+    auto new_size = old_size / size;
+    shape.Set(0, Integer(new_size));
+    ret.push_back(TensorType(shape, DataType(tpn->dtype)));
+  }
+  return TupleType(ret);
+}
+
+RAF_OP_TYPE("raf.op._group_reduce_scatter", "NCCLGroupReduceScatter", GroupReduceScatterInfer);
+
+
 Type SendInfer(const CallValues& value) {
   const auto* args = value->args.as<SendArgs>();
   CHECK(args != nullptr);
@@ -90,6 +112,24 @@ Type AllGatherInfer(const CallValues& value) {
 }
 
 RAF_OP_TYPE("raf.op._allgather", "NCCLAllGather", AllGatherInfer);
+
+Type GroupAllGatherInfer(const CallValues& value) {
+  const auto* args = value->args.as<GroupAllgatherArgs>();
+  CHECK(args != nullptr);
+  int size = Communicator::Get()->size;
+  Array<Type> ret;
+  for(const auto& tv: args->tensor_list)
+  {
+    auto ttype = GetType(tv).as<TensorTypeNode>();
+    auto shape = ttype->shape;
+    auto new_size = shape[args->axis].as<IntImmNode>()->value * size;
+    shape.Set(args->axis, Integer(new_size));
+    ret.push_back(TensorType(shape, DataType(ttype->dtype)));
+  }
+  return TupleType(ret);
+}
+
+RAF_OP_TYPE("raf.op._group_allgather", "NCCLGroupAllGather", GroupAllGatherInfer);
 
 }  // namespace op
 }  // namespace raf

--- a/src/op/ty/collective_comm.cc
+++ b/src/op/ty/collective_comm.cc
@@ -59,10 +59,9 @@ RAF_OP_TYPE("raf.op._reduce_scatter", "NCCLReduceScatter", ReduceScatterInfer);
 Type GroupReduceScatterInfer(const CallValues& value) {
   const auto* args = value->args.as<GroupReduceScatterArgs>();
   CHECK(args != nullptr);
-  int size =Communicator::Get()->size;
+  int size = Communicator::Get()->size;
   Array<Type> ret;
-  for (const auto& tv: args->tensor_list)
-  {
+  for (const auto& tv : args->tensor_list) {
     const auto& ty = GetType(tv);
     auto tpn = ty.as<TensorTypeNode>();
     auto shape = tpn->shape;
@@ -76,7 +75,6 @@ Type GroupReduceScatterInfer(const CallValues& value) {
 }
 
 RAF_OP_TYPE("raf.op._group_reduce_scatter", "NCCLGroupReduceScatter", GroupReduceScatterInfer);
-
 
 Type SendInfer(const CallValues& value) {
   const auto* args = value->args.as<SendArgs>();
@@ -118,8 +116,7 @@ Type GroupAllGatherInfer(const CallValues& value) {
   CHECK(args != nullptr);
   int size = Communicator::Get()->size;
   Array<Type> ret;
-  for(const auto& tv: args->tensor_list)
-  {
+  for (const auto& tv : args->tensor_list) {
     auto ttype = GetType(tv).as<TensorTypeNode>();
     auto shape = ttype->shape;
     auto new_size = shape[args->axis].as<IntImmNode>()->value * size;

--- a/src/op/ty/transform.cc
+++ b/src/op/ty/transform.cc
@@ -479,6 +479,20 @@ Type CastLikeInfer(const CallValues& value) {
 
 RAF_OP_TYPE("raf.op.cast_like", "CastLike", CastLikeInfer);
 
+Type GroupCastInfer(const CallValues& value) {
+  const auto* args = value->args.as<GroupCastArgs>();
+  CHECK(args != nullptr);
+  Array<Type> ret;
+  DataType dtype = DataType(ir::String2DLDataType(args->dtype));
+  for (int i =0; i<args->tensor_list.size(); ++i){
+  TensorType data = Downcast<TensorType>(GetType(args->tensor_list[i]));
+  ret.push_back(TensorType(data->shape, dtype));
+  }
+  return TupleType(ret);
+}
+
+RAF_OP_TYPE("raf.op.group_cast", "GroupCast", GroupCastInfer);
+
 Type ExpandDimsInfer(const CallValues& value) {
   const auto* args = value->args.as<ExpandDimsArgs>();
   CHECK(args);

--- a/src/op/ty/transform.cc
+++ b/src/op/ty/transform.cc
@@ -484,9 +484,9 @@ Type GroupCastInfer(const CallValues& value) {
   CHECK(args != nullptr);
   Array<Type> ret;
   DataType dtype = DataType(ir::String2DLDataType(args->dtype));
-  for (int i =0; i<args->tensor_list.size(); ++i){
-  TensorType data = Downcast<TensorType>(GetType(args->tensor_list[i]));
-  ret.push_back(TensorType(data->shape, dtype));
+  for (int i = 0; i < args->tensor_list.size(); ++i) {
+    TensorType data = Downcast<TensorType>(GetType(args->tensor_list[i]));
+    ret.push_back(TensorType(data->shape, dtype));
   }
   return TupleType(ret);
 }

--- a/tests/python/distributed/test_collective_communication.py
+++ b/tests/python/distributed/test_collective_communication.py
@@ -549,7 +549,7 @@ def test_group_allgather(axis):
     y2 = raf.array(y2, device=device)
 
     model.to(device=device)
-    y = run_model(model, [x1, x2, y1, y2], device)
+    run_model(model, [x1, x2, y1, y2], device)
 
     if rank == 0:
         x1 = x1.numpy()

--- a/tests/python/distributed/test_collective_communication.py
+++ b/tests/python/distributed/test_collective_communication.py
@@ -550,7 +550,7 @@ def test_group_allgather(axis):
 
     model.to(device=device)
     y = run_model(model, [x1, x2, y1, y2], device)
-    
+
     if rank == 0:
         x1 = x1.numpy()
         x2 = x2.numpy()
@@ -569,7 +569,7 @@ def test_group_reduce_scatter(computation):
 
         @raf.model.trace
         def forward(self, x, y):
-            out = raf.group_reduce_scatter([x,y], computation)
+            out = raf.group_reduce_scatter([x, y], computation)
             return out
 
     if computation == "avg" and raf.build.with_nccl() < 21000:

--- a/tests/python/op/tvm/test_tvm_transform.py
+++ b/tests/python/op/tvm/test_tvm_transform.py
@@ -1073,5 +1073,48 @@ def test_cumsum(device, shape, axis, dtype, exclusive):
         check(m_x.grad, t_x.grad, rtol=tol, atol=tol)
 
 
+@pytest.mark.parametrize("device", get_testable_devices())
+@pytest.mark.parametrize("shape", [(3, 4, 2)])
+@pytest.mark.parametrize("itype", ["float16", "float32", "int32", "int64", "bool"])
+@pytest.mark.parametrize("otype", ["float16", "float32", "int32", "int64", "bool"])
+def test_group_cast(shape, device, itype, otype):
+    # TODO(hgt312): The TVM JIT cast kernel in LLVM crashed for float16. See:
+    # https://discuss.tvm.apache.org/t/cast-from-float64-to-float16-cause-segmentation-fault
+    if (itype, otype, device) == ("float64", "float16", "cpu"):
+        pytest.skip(
+            "The TVM JIT cast kernel in LLVM crashed for float16."
+        )
+    class TestGroupModel(raf.Model):
+        def build(self):
+            pass
+
+        @raf.model.trace
+        def forward(self, tensors):  # pylint: disable=no-self-use
+            return raf.group_cast(tensors, otype)
+
+    class TestModel(raf.Model):
+        def build(self):
+            pass
+
+        @raf.model.trace
+        def forward(self, in0, in1, in2):  # pylint: disable=no-self-use
+            out0 = raf.cast(in0, otype)
+            out1 = raf.cast(in1, otype)
+            out2 = raf.cast(in2, otype)
+            return out0, out1, out2
+
+    group_m = TestGroupModel()
+    cast_m = TestModel()
+    m1, _ = randn(shape, device=device)
+    m2, _ = randn(shape, device=device)
+    m3, _ = randn(shape, device=device)
+
+    group_out = run_vm_model(group_m, device, [[m1, m2, m3]])
+    out = run_vm_model(cast_m, device, [m1, m2, m3])
+    check(group_out[0], out[0])
+    check(group_out[1], out[1])
+    check(group_out[2], out[2])
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/python/op/tvm/test_tvm_transform.py
+++ b/tests/python/op/tvm/test_tvm_transform.py
@@ -1081,9 +1081,8 @@ def test_group_cast(shape, device, itype, otype):
     # TODO(hgt312): The TVM JIT cast kernel in LLVM crashed for float16. See:
     # https://discuss.tvm.apache.org/t/cast-from-float64-to-float16-cause-segmentation-fault
     if (itype, otype, device) == ("float64", "float16", "cpu"):
-        pytest.skip(
-            "The TVM JIT cast kernel in LLVM crashed for float16."
-        )
+        pytest.skip("The TVM JIT cast kernel in LLVM crashed for float16.")
+
     class TestGroupModel(raf.Model):
         def build(self):
             pass

--- a/tests/python/op/tvm/test_tvm_transform.py
+++ b/tests/python/op/tvm/test_tvm_transform.py
@@ -1091,7 +1091,7 @@ def test_group_cast(shape, device, itype, otype):
         def forward(self, tensors):  # pylint: disable=no-self-use
             return raf.group_cast(tensors, otype)
 
-    class TestModel(raf.Model):
+    class TestCastModel(raf.Model):
         def build(self):
             pass
 
@@ -1103,7 +1103,7 @@ def test_group_cast(shape, device, itype, otype):
             return out0, out1, out2
 
     group_m = TestGroupModel()
-    cast_m = TestModel()
+    cast_m = TestCastModel()
     m1, _ = randn(shape, device=device)
     m2, _ = randn(shape, device=device)
     m3, _ = randn(shape, device=device)

--- a/tests/python/pass/test_pass_inplace_update.py
+++ b/tests/python/pass/test_pass_inplace_update.py
@@ -372,8 +372,8 @@ def test_group_allgather():
             pass
 
         @raf.model.trace
-        def forward(self, x1, x2, y1, y2):
-            out = raf.group_allgather([x1, x2], 0, [y1, y2])
+        def forward(self, x1, x2, out1, out2):
+            out = raf.group_allgather([x1, x2], 0, [out1, out2])
             return out[0], out[1]
 
     model = TestModel()
@@ -383,12 +383,12 @@ def test_group_allgather():
     x2 = np.ones(shape=(4, 4), dtype="float32")
     x1 = raf.array(x1, device=device)
     x2 = raf.array(x2, device=device)
-    y1 = np.ones(shape=(8, 4), dtype="float32")
-    y2 = np.ones(shape=(8, 4), dtype="float32")
-    y1 = raf.array(y1, device=device)
-    y2 = raf.array(y2, device=device)
+    out1 = np.ones(shape=(8, 4), dtype="float32")
+    out2 = np.ones(shape=(8, 4), dtype="float32")
+    out1 = raf.array(out1, device=device)
+    out2 = raf.array(out2, device=device)
 
-    bytecode = compile_vm_model(model, device, [x1, x2, y1, y2])
+    bytecode = compile_vm_model(model, device, [x1, x2, out1, out2])
     assert bytecode.count("alloc_tensor") == 0
 
 


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR implements some group ops for ZeRO optimizations.  
There are 3 group operators:
`group_cast`: cast a tensor list.
`group_allgather`: perform allgather for each tensor in the group. The result is in-place updated. So tensor allocation for this op.  The in-place update implementation may need to refactor after we finish: https://github.com/meta-project/meta/issues/758
`group_reduce_scatter`: perform reduce_scatter for each tensor in the group

## Checklist ##

- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @awslabs/raf-reviewer
