### PR TITLE
[PASS] skip non-TVM op in Estimate  flops pass

### DIFF
--- a/src/pass/estimate_flops.cc
+++ b/src/pass/estimate_flops.cc
@@ -62,6 +62,8 @@ void FLOPSEstimater::VisitExpr_(const CallNode* call) {
     auto tvm_op = OpDialect::Lower(base_op, "tvm");
     // skip this op if it does not have a TVM dialect
     if (!tvm_op.defined()) {
+      var_flops_map_[curr_let_] = std::numeric_limits<float>::infinity();
+      LOG(WARNING) << "Op " << base_op->name << " doesn't have TVM dialect, skip estimating FLOPS";
       return;
     }
   }

--- a/src/pass/estimate_flops.cc
+++ b/src/pass/estimate_flops.cc
@@ -56,12 +56,14 @@ void FLOPSEstimater::VisitExpr_(const LetNode* op) {
 }
 
 void FLOPSEstimater::VisitExpr_(const CallNode* call) {
-  const Op& op = Downcast<Op>(call->op);
-  auto base_op = IsDialectOp(op) ? GetBaseOp(op) : op;
-  auto tvm_op = OpDialect::Lower(base_op, "tvm");
-  // skip this op if it does not have a TVM dialect
-  if (!tvm_op.defined()) {
-    return;
+  if (call->op.as<OpNode>()) {
+    const Op& op = Downcast<Op>(call->op);
+    auto base_op = IsDialectOp(op) ? GetBaseOp(op) : op;
+    auto tvm_op = OpDialect::Lower(base_op, "tvm");
+    // skip this op if it does not have a TVM dialect
+    if (!tvm_op.defined()) {
+      return;
+    }
   }
   Array<Type> param_types;
   for (auto arg : call->args) {

--- a/src/pass/estimate_flops.cc
+++ b/src/pass/estimate_flops.cc
@@ -56,6 +56,13 @@ void FLOPSEstimater::VisitExpr_(const LetNode* op) {
 }
 
 void FLOPSEstimater::VisitExpr_(const CallNode* call) {
+  const Op& op = Downcast<Op>(call->op);
+  auto base_op = IsDialectOp(op) ? GetBaseOp(op) : op;
+  auto tvm_op = OpDialect::Lower(base_op, "tvm");
+  // skip this op if it does not have a TVM dialect
+  if (!tvm_op.defined()) {
+    return;
+  }
   Array<Type> param_types;
   for (auto arg : call->args) {
     param_types.push_back(arg->checked_type());


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
If op does not have a TVM dialect, skip the flops estimation.

## Checklist ##

- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @awslabs/raf-reviewer
