### PR TITLE
[Codegen] Don't run clang-format

### DIFF
--- a/scripts/src_codegen/run_all.sh
+++ b/scripts/src_codegen/run_all.sh
@@ -7,10 +7,10 @@ set -u
 set -o pipefail
 set -x
 
-python3 -m scripts.src_codegen.main_cxx_schema && scripts/lint/run-clang-format.sh src/op/schema/*
-python3 -m scripts.src_codegen.main_cxx_reg && scripts/lint/run-clang-format.sh src/op/regs/regs.cc
+python3 -m scripts.src_codegen.main_cxx_schema
+python3 -m scripts.src_codegen.main_cxx_reg
 python3 -m scripts.src_codegen.main_py_sym
 python3 -m scripts.src_codegen.main_py_imp
 python3 -m scripts.src_codegen.main_py_ir
 rm -rf python/raf/_ffi && mkdir python/raf/_ffi && python3 -m scripts.src_codegen.main_py_ffi
-python3 -m scripts.src_codegen.main_cxx_tvm_op && scripts/lint/run-clang-format.sh src/op/regs/tvm_op_regs.cc
+python3 -m scripts.src_codegen.main_cxx_tvm_op


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
Do not run clang-format to auto-generated files as we don't check in them anymore.

## Checklist ##

- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @awslabs/raf-reviewer @hzfan 
