### PR TITLE
[Remat][Bugfix] Enhance the rematerialization pass to handle nested tuples

### DIFF
--- a/src/pass/liveness_analysis.cc
+++ b/src/pass/liveness_analysis.cc
@@ -351,12 +351,12 @@ Var LivenessAnalyzer::CreateTensorVar(const Type& type) {
   return VarCreator(this).Run(type);
 }
 
-/*! 
+/*!
  * \brief Calculate the byte compact size of the given type. If the type is a tuple,
  * then the size of each tensor in the tuple will be returned. Note that size 0 means
  * a tensor with dynamic shape. If the input type contains nested tuples, the nested
  * tuples are flattened and a flat vector of sizes is returned at the end. The order
- * of the fields is preserved. 
+ * of the fields is preserved.
  */
 std::vector<int64_t> CalcBytesCompactSizes(const Type& type) {
   tvm::Array<Type> ty_stack;
@@ -367,7 +367,7 @@ std::vector<int64_t> CalcBytesCompactSizes(const Type& type) {
     ty_stack.pop_back();
     if (auto tuple_ty_node = ty.as<TupleTypeNode>()) {
       // If the current type corresponds to a tuple, process the type of each field later
-      for (auto it = tuple_ty_node->fields.rbegin(); it != tuple_ty_node->fields.rend(); it ++)
+      for (auto it = tuple_ty_node->fields.rbegin(); it != tuple_ty_node->fields.rend(); it++)
         ty_stack.push_back(*it);
     } else if (auto tensor_ty_node = ty.as<TensorTypeNode>()) {
       // Tensor types are added to the final list and sizes will be calculated
@@ -378,7 +378,7 @@ std::vector<int64_t> CalcBytesCompactSizes(const Type& type) {
       throw;
     }
   }
- 
+
   std::vector<int64_t> sizes;
   for (auto ttype : ttypes) {
     sizes.push_back(common::shape_utils::BytesCompactTensor(ttype));

--- a/src/pass/liveness_analysis.cc
+++ b/src/pass/liveness_analysis.cc
@@ -359,7 +359,7 @@ Var LivenessAnalyzer::CreateTensorVar(const Type& type) {
  * of the fields is preserved. 
  */
 std::vector<int64_t> CalcBytesCompactSizes(const Type& type) {
-  std::vector<const Type> ty_stack;
+  tvm::Array<Type> ty_stack;
   std::vector<const TensorTypeNode*> ttypes;
   ty_stack.push_back(type);
   while (!ty_stack.empty()) {
@@ -367,8 +367,8 @@ std::vector<int64_t> CalcBytesCompactSizes(const Type& type) {
     ty_stack.pop_back();
     if (auto tuple_ty_node = ty.as<TupleTypeNode>()) {
       // If the current type corresponds to a tuple, process the type of each field later
-      for (auto field : tuple_ty_node->fields)
-        ty_stack.push_back(field);
+      for (auto it = tuple_ty_node->fields.rbegin(); it != tuple_ty_node->fields.rend(); it ++)
+        ty_stack.push_back(*it);
     } else if (auto tensor_ty_node = ty.as<TensorTypeNode>()) {
       // Tensor types are added to the final list and sizes will be calculated
       ttypes.push_back(tensor_ty_node);

--- a/src/pass/rematerialization.cc
+++ b/src/pass/rematerialization.cc
@@ -896,7 +896,6 @@ class Rematerializer::TensorAnalyzer : public ExprVisitor {
 
   /*! \brief Visit each let statement and return the analyzed information of each tensor. */
   TensorInfos Run() {
-    LOG(INFO) << "Function: " << ir::AsText(func_);
     // Analyze parameters.
     for (const auto& var : func_->params) {
       auto liveness_vars = analyzer_->GetTensorVars(var);

--- a/src/pass/rematerialization.cc
+++ b/src/pass/rematerialization.cc
@@ -864,10 +864,10 @@ class Rematerializer::TensorAnalyzer : public ExprVisitor {
   ~TensorAnalyzer() {
   }
 
-  /*! 
+  /*!
    * \brief Get a list of liveness vars for the current let var. This function uses a DFS to handle
    * nested tuples. The returned array contains a flat list of vars. The relative order of tuple
-   * fields is preserved. 
+   * fields is preserved.
    */
   tvm::Array<Var> GetLivenessVars(const Var& curr_let) {
     tvm::Array<Var> result_vars;
@@ -880,7 +880,7 @@ class Rematerializer::TensorAnalyzer : public ExprVisitor {
       CHECK_GT(liveness_vars.size(), 0U);
       if (liveness_vars.size() > 1) {
         // If the current let var corresponds to a tuple, the tuple fields should be processed later
-        for (auto it = liveness_vars.rbegin(); it != liveness_vars.rend(); it ++)
+        for (auto it = liveness_vars.rbegin(); it != liveness_vars.rend(); it++)
           var_stack.push_back(*it);
       } else if (let_var_set_.count(liveness_vars[0])) {
         // If this "liveness var" points to a real var rather than an actual liveness var

--- a/src/pass/rematerialization.cc
+++ b/src/pass/rematerialization.cc
@@ -32,7 +32,7 @@ constexpr float kMegaBytes = 1048576;
 constexpr float kGigaBytes = 1073741824;
 
 // Whether to display verbose logging.
-#define SHOW_VERBOSE_LOG 1
+#define SHOW_VERBOSE_LOG 0
 
 // Whether to update tensor index when rematerialization. If defined, then
 // the rematerialized tensors are less likely to be freed and rematerialized again.
@@ -880,8 +880,8 @@ class Rematerializer::TensorAnalyzer : public ExprVisitor {
       CHECK_GT(liveness_vars.size(), 0U);
       if (liveness_vars.size() > 1) {
         // If the current let var corresponds to a tuple, the tuple fields should be processed later
-        for (auto next_v : liveness_vars)
-          var_stack.push_back(next_v);
+        for (auto it = liveness_vars.rbegin(); it != liveness_vars.rend(); it ++)
+          var_stack.push_back(*it);
       } else if (let_var_set_.count(liveness_vars[0])) {
         // If this "liveness var" points to a real var rather than an actual liveness var
         // it should also be processed later
@@ -915,20 +915,6 @@ class Rematerializer::TensorAnalyzer : public ExprVisitor {
     for (int i = 0; i < n; ++i) {
       curr_let_ = vars[i];
       auto liveness_vars = GetLivenessVars(curr_let_);
-      /* 
-      auto liveness_vars = analyzer_->GetTensorVars(curr_let_);
-
-      // In the case of tuple with may_share, liveness vars may point to the real tensor.
-      for (size_t i = 0; i < liveness_vars.size(); ++i) {
-        auto real_liveness_var = liveness_vars[i];
-        while (let_var_set_.find(real_liveness_var) != let_var_set_.end()) {
-          auto cand_liveness_vars = analyzer_->GetTensorVars(real_liveness_var);
-          CHECK_EQ(cand_liveness_vars.size(), 1U);
-          real_liveness_var = cand_liveness_vars[0];
-        }
-        liveness_vars.Set(i, real_liveness_var);
-      }
-      */
 
       // Visit the expression to analyze the use count
       ExprVisitor::VisitExpr(exprs[i]);

--- a/tests/python/pass/test_pass_rematerialization.py
+++ b/tests/python/pass/test_pass_rematerialization.py
@@ -479,6 +479,47 @@ def test_tuple():
     verify_remat(model, args, peak_size - 1, expected(), (peak_size, peak_size - 1))
 
 
+def test_nested_tuple():
+    """
+    A simple test program to check whether the remat pass can handle nested
+    tuples without crashing. No actual rematerialization is taking place.
+    """
+    device = "cpu"
+    shape = (16, 16, 64, 64)  # 4 MBs
+
+    def get_mod():
+        add_op = raf._ffi.op.GetOp("raf.op.add")
+        relu_op = raf._ffi.op.GetOp("raf.op.relu")
+        null = raf.ir.const(None)
+
+        # param: 12 MBs
+        p_0 = raf.ir.var("p0", shape=shape)
+        p_1 = raf.ir.var("p1", shape=shape)
+        p_2 = raf.ir.var("p2", shape=shape)
+
+        sb = ScopeBuilder()
+        # a_1: 4 MBs, total 16 MBs
+        a_1 = sb.let("a1", relay.Call(add_op, [p_0, p_1, null, null]))
+        # a_2: 4 MBs, total 20 MBs
+        a_2 = sb.let("a2", relay.Call(relu_op, [a_1]))
+        # a_3: 4 MBs, total 24 MBs
+        a_3 = sb.let("a3", relay.Call(add_op, [a_1, p_2, null, null]))
+        # Package the three tensors into a nested tuple and return
+        a_4 = sb.let("a4", relay.Tuple([a_2, a_3]))
+        a_5 = sb.let("a5", relay.Tuple([a_4, a_1]))
+        sb.ret(a_5)
+        func = relay.Function([p_0, p_1, p_2], sb.get())
+        return tvm.IRModule.from_expr(func)
+
+    m_p0, _ = randn(shape, device=device)
+    m_p1, _ = randn(shape, device=device)
+    m_p2, _ = randn(shape, device=device)
+
+    # Set the memory budget to be higher than the peak
+    # The IR should remain unchanged after the remat pass
+    verify_remat(get_mod(), [m_p0, m_p1, m_p2], 28, get_mod()["main"], (24.00, 24.00))
+
+
 def test_reshape():
     device = "cpu"
     shape = (512, 512)  # 1 MB.


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR addresses issue #8  and presents a small fix for the rematerialization pass to handle nested tuples. Specifically, it handles cases like the following:
```
...
let a = (x0, x1)
...
let b = some_call()
...
let c = (a, b)
```
Without this patch the remat pass would error out when processing `c` because of a simplified assumption we made in the first version of the pass. **Notice that this fix does not address the case where a call node directly produces a nested tuple (which does not exist in current RAF as far as I know).**

ResNet50 with AMP can now be compiled with rematerialization turned on, and the benchmarked latency is ~35ms per batch when the batch size is 16. 

I will add a test for nested tuples later. Please review the changes first. 

## Checklist ##

- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @awslabs/raf-reviewer @comaniac 
