### PR TITLE
[VM] Support AllocStorage sync/async

### DIFF
--- a/include/raf/vm/bytecode.h
+++ b/include/raf/vm/bytecode.h
@@ -144,8 +144,12 @@ struct Instruction {
       Index alignment;
       /*! \brief The hint of the dtype. */
       DLDataType dtype_hint;
+      /*! \brief The allocated device type. */
       DevType device_type;
+      /*! \brief The allocated device ID. */
       Index device_id;
+      /*! \brief Whether the allocated storage is sync. */
+      bool sync;
     } alloc_storage;
     struct /* AllocTensor Operands */ {
       /*! \brief The storage to allocate from. */
@@ -395,10 +399,12 @@ struct Instruction {
    * \param device_type The device type.
    * \param device_id The device ID.
    * \param dst The destination to place the storage.
+   * \param sync Whether the allocated storage is sync.
    * \return The alloc storage instruction.
    */
   static Instruction AllocStorage(RegName size, RegName alignment, DLDataType dtype_hint,
-                                  DevType device_type, Index device_id, RegName dst);
+                                  DevType device_type, Index device_id, RegName dst,
+                                  bool sync = false);
 
   /*!
    * \brief Free a tensor or a storage.

--- a/include/raf/vm/bytecode.h
+++ b/include/raf/vm/bytecode.h
@@ -148,8 +148,8 @@ struct Instruction {
       DevType device_type;
       /*! \brief The allocated device ID. */
       Index device_id;
-      /*! \brief Whether the allocated storage is sync. */
-      bool sync;
+      /*! \brief Allocate storage async if available. */
+      bool async;
     } alloc_storage;
     struct /* AllocTensor Operands */ {
       /*! \brief The storage to allocate from. */
@@ -399,12 +399,12 @@ struct Instruction {
    * \param device_type The device type.
    * \param device_id The device ID.
    * \param dst The destination to place the storage.
-   * \param sync Whether the allocated storage is sync.
+   * \param async Allocate storage async if available.
    * \return The alloc storage instruction.
    */
   static Instruction AllocStorage(RegName size, RegName alignment, DLDataType dtype_hint,
                                   DevType device_type, Index device_id, RegName dst,
-                                  bool sync = false);
+                                  bool async = true);
 
   /*!
    * \brief Free a tensor or a storage.

--- a/include/raf/vm/bytecode.h
+++ b/include/raf/vm/bytecode.h
@@ -148,8 +148,8 @@ struct Instruction {
       DevType device_type;
       /*! \brief The allocated device ID. */
       Index device_id;
-      /*! \brief Allocate storage async if available. */
-      bool async;
+      /*! \brief Allocate storage alloc_async if available. */
+      bool alloc_async;
     } alloc_storage;
     struct /* AllocTensor Operands */ {
       /*! \brief The storage to allocate from. */
@@ -399,12 +399,12 @@ struct Instruction {
    * \param device_type The device type.
    * \param device_id The device ID.
    * \param dst The destination to place the storage.
-   * \param async Allocate storage async if available.
+   * \param alloc_async Allocate storage async if available.
    * \return The alloc storage instruction.
    */
   static Instruction AllocStorage(RegName size, RegName alignment, DLDataType dtype_hint,
                                   DevType device_type, Index device_id, RegName dst,
-                                  bool async = true);
+                                  bool alloc_async = true);
 
   /*!
    * \brief Free a tensor or a storage.

--- a/include/raf/vm/vm.h
+++ b/include/raf/vm/vm.h
@@ -348,7 +348,8 @@ class VirtualMachine : public tvm::runtime::ModuleNode {
    * \return The allocated memory.
    */
   inline std::shared_ptr<Memory> Alloc(const VMContext& ctx, Device dev, int64_t nbytes,
-                                       int64_t alignment = kDefaultMemoryAlignment) const;
+                                       int64_t alignment = kDefaultMemoryAlignment,
+                                       bool async = true) const;
   /*! \brief Run VM dispatch loop. */
   virtual void RunLoop(VMContext& ctx);
   /*! \brief Prepare an OpEnv with its inputs and output */

--- a/include/raf/vm/vm.h
+++ b/include/raf/vm/vm.h
@@ -349,7 +349,7 @@ class VirtualMachine : public tvm::runtime::ModuleNode {
    */
   inline std::shared_ptr<Memory> Alloc(const VMContext& ctx, Device dev, int64_t nbytes,
                                        int64_t alignment = kDefaultMemoryAlignment,
-                                       bool async = true) const;
+                                       bool alloc_async = true) const;
   /*! \brief Run VM dispatch loop. */
   virtual void RunLoop(VMContext& ctx);
   /*! \brief Prepare an OpEnv with its inputs and output */

--- a/scripts/src_codegen/def_schema.py
+++ b/scripts/src_codegen/def_schema.py
@@ -867,7 +867,7 @@ SCHEMAS = {
         Arg(name="device_type", cxx_type="int"),
         Arg(name="device_id", cxx_type="int"),
         Arg(name="dtype", cxx_type="std::string", cxx_default='"float32"', py_default='"float32"'),
-        Arg(name="async", cxx_type="bool", cxx_default=True),
+        Arg(name="alloc_async", cxx_type="bool", cxx_default=True),
     ],
     "vm.h::alloc_tensor": [
         Arg(name="storage", cxx_type="value::BaseTensorValue"),

--- a/scripts/src_codegen/def_schema.py
+++ b/scripts/src_codegen/def_schema.py
@@ -867,7 +867,7 @@ SCHEMAS = {
         Arg(name="device_type", cxx_type="int"),
         Arg(name="device_id", cxx_type="int"),
         Arg(name="dtype", cxx_type="std::string", cxx_default='"float32"', py_default='"float32"'),
-        Arg(name="sync", cxx_type="bool", cxx_default=False),
+        Arg(name="async", cxx_type="bool", cxx_default=True),
     ],
     "vm.h::alloc_tensor": [
         Arg(name="storage", cxx_type="value::BaseTensorValue"),

--- a/scripts/src_codegen/def_schema.py
+++ b/scripts/src_codegen/def_schema.py
@@ -867,6 +867,7 @@ SCHEMAS = {
         Arg(name="device_type", cxx_type="int"),
         Arg(name="device_id", cxx_type="int"),
         Arg(name="dtype", cxx_type="std::string", cxx_default='"float32"', py_default='"float32"'),
+        Arg(name="sync", cxx_type="bool", cxx_default=False),
     ],
     "vm.h::alloc_tensor": [
         Arg(name="storage", cxx_type="value::BaseTensorValue"),

--- a/src/impl/vm/bytecode.cc
+++ b/src/impl/vm/bytecode.cc
@@ -376,7 +376,8 @@ Instruction Instruction::AllocTensorReg(RegName storage, Index offset, RegName s
 }
 
 Instruction Instruction::AllocStorage(RegName size, Index alignment, DLDataType dtype_hint,
-                                      DevType device_type, Index device_id, Index dst, bool async) {
+                                      DevType device_type, Index device_id, Index dst,
+                                      bool alloc_async) {
   Instruction instr;
   instr.op = Opcode::AllocStorage;
   instr.dst = dst;
@@ -385,7 +386,7 @@ Instruction Instruction::AllocStorage(RegName size, Index alignment, DLDataType 
   instr.alloc_storage.dtype_hint = dtype_hint;
   instr.alloc_storage.device_type = device_type;
   instr.alloc_storage.device_id = device_id;
-  instr.alloc_storage.async = async;
+  instr.alloc_storage.alloc_async = alloc_async;
   return instr;
 }
 
@@ -696,7 +697,7 @@ void InstructionPrint(std::ostream& os, const Instruction& instr) {
       os << "alloc_storage $" << instr.dst << " $" << instr.alloc_storage.allocation_size << " "
          << instr.alloc_storage.alignment << " "
          << tvm::runtime::DLDataType2String(instr.alloc_storage.dtype_hint);
-      if (instr.alloc_storage.async) {
+      if (instr.alloc_storage.alloc_async) {
         os << "(async)";
       }
       break;

--- a/src/impl/vm/bytecode.cc
+++ b/src/impl/vm/bytecode.cc
@@ -376,7 +376,7 @@ Instruction Instruction::AllocTensorReg(RegName storage, Index offset, RegName s
 }
 
 Instruction Instruction::AllocStorage(RegName size, Index alignment, DLDataType dtype_hint,
-                                      DevType device_type, Index device_id, Index dst) {
+                                      DevType device_type, Index device_id, Index dst, bool sync) {
   Instruction instr;
   instr.op = Opcode::AllocStorage;
   instr.dst = dst;
@@ -385,6 +385,7 @@ Instruction Instruction::AllocStorage(RegName size, Index alignment, DLDataType 
   instr.alloc_storage.dtype_hint = dtype_hint;
   instr.alloc_storage.device_type = device_type;
   instr.alloc_storage.device_id = device_id;
+  instr.alloc_storage.sync = sync;
   return instr;
 }
 
@@ -695,6 +696,9 @@ void InstructionPrint(std::ostream& os, const Instruction& instr) {
       os << "alloc_storage $" << instr.dst << " $" << instr.alloc_storage.allocation_size << " "
          << instr.alloc_storage.alignment << " "
          << tvm::runtime::DLDataType2String(instr.alloc_storage.dtype_hint);
+      if (instr.alloc_storage.sync) {
+        os << "(sync)";
+      }
       break;
     }
     case Opcode::Free: {

--- a/src/impl/vm/bytecode.cc
+++ b/src/impl/vm/bytecode.cc
@@ -376,7 +376,7 @@ Instruction Instruction::AllocTensorReg(RegName storage, Index offset, RegName s
 }
 
 Instruction Instruction::AllocStorage(RegName size, Index alignment, DLDataType dtype_hint,
-                                      DevType device_type, Index device_id, Index dst, bool sync) {
+                                      DevType device_type, Index device_id, Index dst, bool async) {
   Instruction instr;
   instr.op = Opcode::AllocStorage;
   instr.dst = dst;
@@ -385,7 +385,7 @@ Instruction Instruction::AllocStorage(RegName size, Index alignment, DLDataType 
   instr.alloc_storage.dtype_hint = dtype_hint;
   instr.alloc_storage.device_type = device_type;
   instr.alloc_storage.device_id = device_id;
-  instr.alloc_storage.sync = sync;
+  instr.alloc_storage.async = async;
   return instr;
 }
 
@@ -696,8 +696,8 @@ void InstructionPrint(std::ostream& os, const Instruction& instr) {
       os << "alloc_storage $" << instr.dst << " $" << instr.alloc_storage.allocation_size << " "
          << instr.alloc_storage.alignment << " "
          << tvm::runtime::DLDataType2String(instr.alloc_storage.dtype_hint);
-      if (instr.alloc_storage.sync) {
-        os << "(sync)";
+      if (instr.alloc_storage.async) {
+        os << "(async)";
       }
       break;
     }

--- a/src/impl/vm/compiler.cc
+++ b/src/impl/vm/compiler.cc
@@ -486,17 +486,17 @@ class VMFunctionCompiler : ExprFunctor<void(const Expr& expr)> {
                    std::string dtype_s = dtype_val.as<StringValueObj>()->value;
                    DataType dtype(String2DLDataType(dtype_s));
 
-                   // sync
-                   bool sync = false;
+                   // async
+                   bool async = true;
                    if (args.size() == 6) {
                      CHECK(args[5]->IsInstance<ConstantNode>());
-                     auto persist_val = args[5].as<ConstantNode>()->value;
-                     CHECK(persist_val->IsInstance<BoolValueObj>());
-                     sync = persist_val.as<BoolValueObj>()->value;
+                     auto async_val = args[5].as<ConstantNode>()->value;
+                     CHECK(async_val->IsInstance<BoolValueObj>());
+                     async = async_val.as<BoolValueObj>()->value;
                    }
 
                    Emit(Instruction::AllocStorage(size_register, alignment, dtype, device_type,
-                                                  device_id, NewRegister(), sync));
+                                                  device_id, NewRegister(), async));
                  })
           .Match("raf.op.vm.free",
                  [this](const Array<Expr>& args, const Attrs& attrs, const Array<Type>& type_arg) {

--- a/src/impl/vm/compiler.cc
+++ b/src/impl/vm/compiler.cc
@@ -486,17 +486,17 @@ class VMFunctionCompiler : ExprFunctor<void(const Expr& expr)> {
                    std::string dtype_s = dtype_val.as<StringValueObj>()->value;
                    DataType dtype(String2DLDataType(dtype_s));
 
-                   // async
-                   bool async = true;
+                   // alloc_async
+                   bool alloc_async = true;
                    if (args.size() == 6) {
                      CHECK(args[5]->IsInstance<ConstantNode>());
                      auto async_val = args[5].as<ConstantNode>()->value;
                      CHECK(async_val->IsInstance<BoolValueObj>());
-                     async = async_val.as<BoolValueObj>()->value;
+                     alloc_async = async_val.as<BoolValueObj>()->value;
                    }
 
                    Emit(Instruction::AllocStorage(size_register, alignment, dtype, device_type,
-                                                  device_id, NewRegister(), async));
+                                                  device_id, NewRegister(), alloc_async));
                  })
           .Match("raf.op.vm.free",
                  [this](const Array<Expr>& args, const Attrs& attrs, const Array<Type>& type_arg) {

--- a/src/impl/vm/executable.cc
+++ b/src/impl/vm/executable.cc
@@ -327,6 +327,7 @@ VMInstructionSerializer SerializeInstruction(const Instruction& instr) {
       fields.push_back(instr.alloc_storage.device_type);
       fields.push_back(instr.alloc_storage.device_id);
       fields.push_back(instr.dst);
+      fields.push_back(instr.alloc_storage.sync);
       break;
     }
     case Opcode::Free: {
@@ -634,7 +635,7 @@ Instruction DeserializeInstruction(const VMInstructionSerializer& instr) {
       return Instruction::AllocClosure(func_index, free_vars, dst);
     }
     case Opcode::AllocStorage: {
-      DCHECK_GE(instr.fields.size(), 6U);
+      DCHECK_GE(instr.fields.size(), 7U);
       Index allocation_size = instr.fields[0];
       Index alignment = instr.fields[1];
 
@@ -646,9 +647,10 @@ Instruction DeserializeInstruction(const VMInstructionSerializer& instr) {
       DevType device_type = instr.fields[5];
       Index device_id = instr.fields[6];
       RegName dst = instr.fields[7];
+      bool sync = instr.fields[8];
 
       return Instruction::AllocStorage(allocation_size, alignment, dtype, device_type, device_id,
-                                       dst);
+                                       dst, sync);
     }
     case Opcode::Free: {
       DCHECK_EQ(instr.fields.size(), 1U);

--- a/src/impl/vm/executable.cc
+++ b/src/impl/vm/executable.cc
@@ -327,7 +327,7 @@ VMInstructionSerializer SerializeInstruction(const Instruction& instr) {
       fields.push_back(instr.alloc_storage.device_type);
       fields.push_back(instr.alloc_storage.device_id);
       fields.push_back(instr.dst);
-      fields.push_back(instr.alloc_storage.sync);
+      fields.push_back(instr.alloc_storage.async);
       break;
     }
     case Opcode::Free: {
@@ -647,10 +647,10 @@ Instruction DeserializeInstruction(const VMInstructionSerializer& instr) {
       DevType device_type = instr.fields[5];
       Index device_id = instr.fields[6];
       RegName dst = instr.fields[7];
-      bool sync = instr.fields[8];
+      bool async = instr.fields[8];
 
       return Instruction::AllocStorage(allocation_size, alignment, dtype, device_type, device_id,
-                                       dst, sync);
+                                       dst, async);
     }
     case Opcode::Free: {
       DCHECK_EQ(instr.fields.size(), 1U);

--- a/src/impl/vm/executable.cc
+++ b/src/impl/vm/executable.cc
@@ -327,7 +327,7 @@ VMInstructionSerializer SerializeInstruction(const Instruction& instr) {
       fields.push_back(instr.alloc_storage.device_type);
       fields.push_back(instr.alloc_storage.device_id);
       fields.push_back(instr.dst);
-      fields.push_back(instr.alloc_storage.async);
+      fields.push_back(instr.alloc_storage.alloc_async);
       break;
     }
     case Opcode::Free: {
@@ -647,10 +647,10 @@ Instruction DeserializeInstruction(const VMInstructionSerializer& instr) {
       DevType device_type = instr.fields[5];
       Index device_id = instr.fields[6];
       RegName dst = instr.fields[7];
-      bool async = instr.fields[8];
+      bool alloc_async = instr.fields[8];
 
       return Instruction::AllocStorage(allocation_size, alignment, dtype, device_type, device_id,
-                                       dst, async);
+                                       dst, alloc_async);
     }
     case Opcode::Free: {
       DCHECK_EQ(instr.fields.size(), 1U);

--- a/src/impl/vm/vm.cc
+++ b/src/impl/vm/vm.cc
@@ -498,10 +498,10 @@ void VirtualMachine::SetDevices(const std::vector<Device>& devices) {
 
 inline std::shared_ptr<Memory> VirtualMachine::Alloc(const VMContext& ctx, Device dev,
                                                      int64_t nbytes, int64_t alignment,
-                                                     bool sync) const {
+                                                     bool async) const {
   if (dev.device_type() == DevType::kCUDA()) {
 #if CUDA_VERSION >= 11030
-    if (enable_cuda_graph_ || sync) {
+    if (enable_cuda_graph_ || !async) {
       // We can not use async memory allocation in cuda graph tracing mode
       return memory_pool::Memory::Alloc(dev, nbytes, alignment);
     } else {
@@ -708,14 +708,14 @@ void VirtualMachine::HandleIf(VMContext& ctx, const Instruction& instr) {
 void VirtualMachine::HandleAllocStorage(VMContext& ctx, const Instruction& instr) {
   auto size = ctx.LoadScalarInt(instr.alloc_storage.allocation_size);
   auto alignment = instr.alloc_storage.alignment;
-  bool sync = instr.alloc_storage.sync;
+  bool async = instr.alloc_storage.async;
 
   DLOG(INFO) << "AllocStorage: allocation_size=" << size << " alignment=" << alignment
              << " dtype_hint=" << tvm::runtime::DLDataType2String(instr.alloc_storage.dtype_hint)
-             << " sync=" << sync;
+             << " async=" << async;
 
   auto dev = Device(instr.alloc_storage.device_type, instr.alloc_storage.device_id);
-  auto buffer = Alloc(ctx, dev, size, alignment, sync);
+  auto buffer = Alloc(ctx, dev, size, alignment, async);
   auto storage = StorageValue::make(buffer);
   ctx.WriteRegister(instr.dst, storage);
   ctx->pc++;

--- a/src/impl/vm/vm.cc
+++ b/src/impl/vm/vm.cc
@@ -498,10 +498,10 @@ void VirtualMachine::SetDevices(const std::vector<Device>& devices) {
 
 inline std::shared_ptr<Memory> VirtualMachine::Alloc(const VMContext& ctx, Device dev,
                                                      int64_t nbytes, int64_t alignment,
-                                                     bool async) const {
+                                                     bool alloc_async) const {
   if (dev.device_type() == DevType::kCUDA()) {
 #if CUDA_VERSION >= 11030
-    if (enable_cuda_graph_ || !async) {
+    if (enable_cuda_graph_ || !alloc_async) {
       // We can not use async memory allocation in cuda graph tracing mode
       return memory_pool::Memory::Alloc(dev, nbytes, alignment);
     } else {
@@ -708,14 +708,14 @@ void VirtualMachine::HandleIf(VMContext& ctx, const Instruction& instr) {
 void VirtualMachine::HandleAllocStorage(VMContext& ctx, const Instruction& instr) {
   auto size = ctx.LoadScalarInt(instr.alloc_storage.allocation_size);
   auto alignment = instr.alloc_storage.alignment;
-  bool async = instr.alloc_storage.async;
+  bool alloc_async = instr.alloc_storage.alloc_async;
 
   DLOG(INFO) << "AllocStorage: allocation_size=" << size << " alignment=" << alignment
              << " dtype_hint=" << tvm::runtime::DLDataType2String(instr.alloc_storage.dtype_hint)
-             << " async=" << async;
+             << " alloc_async=" << alloc_async;
 
   auto dev = Device(instr.alloc_storage.device_type, instr.alloc_storage.device_id);
-  auto buffer = Alloc(ctx, dev, size, alignment, async);
+  auto buffer = Alloc(ctx, dev, size, alignment, alloc_async);
   auto storage = StorageValue::make(buffer);
   ctx.WriteRegister(instr.dst, storage);
   ctx->pc++;

--- a/src/impl/vm/vm.cc
+++ b/src/impl/vm/vm.cc
@@ -497,10 +497,11 @@ void VirtualMachine::SetDevices(const std::vector<Device>& devices) {
 }
 
 inline std::shared_ptr<Memory> VirtualMachine::Alloc(const VMContext& ctx, Device dev,
-                                                     int64_t nbytes, int64_t alignment) const {
+                                                     int64_t nbytes, int64_t alignment,
+                                                     bool sync) const {
   if (dev.device_type() == DevType::kCUDA()) {
 #if CUDA_VERSION >= 11030
-    if (enable_cuda_graph_) {
+    if (enable_cuda_graph_ || sync) {
       // We can not use async memory allocation in cuda graph tracing mode
       return memory_pool::Memory::Alloc(dev, nbytes, alignment);
     } else {
@@ -707,12 +708,14 @@ void VirtualMachine::HandleIf(VMContext& ctx, const Instruction& instr) {
 void VirtualMachine::HandleAllocStorage(VMContext& ctx, const Instruction& instr) {
   auto size = ctx.LoadScalarInt(instr.alloc_storage.allocation_size);
   auto alignment = instr.alloc_storage.alignment;
+  bool sync = instr.alloc_storage.sync;
 
   DLOG(INFO) << "AllocStorage: allocation_size=" << size << " alignment=" << alignment
-             << " dtype_hint=" << tvm::runtime::DLDataType2String(instr.alloc_storage.dtype_hint);
+             << " dtype_hint=" << tvm::runtime::DLDataType2String(instr.alloc_storage.dtype_hint)
+             << " sync=" << sync;
 
   auto dev = Device(instr.alloc_storage.device_type, instr.alloc_storage.device_id);
-  auto buffer = Alloc(ctx, dev, size, alignment);
+  auto buffer = Alloc(ctx, dev, size, alignment, sync);
   auto storage = StorageValue::make(buffer);
   ctx.WriteRegister(instr.dst, storage);
   ctx->pc++;

--- a/src/pass/memory_plan.cc
+++ b/src/pass/memory_plan.cc
@@ -305,7 +305,7 @@ class MemoryPlanner : public ExprMutator {
 
       auto group_id = tensor_groups_.FindGroupIdByStorageVar(curr_let_);
       if (group_id != -1 && tensor_groups_.groups[group_id].size > 0) {
-        bool async = !tensor_groups_.HasOutputTensor(group_id);
+        bool alloc_async = !tensor_groups_.HasOutputTensor(group_id);
 
         Array<Expr> new_args;
         for (auto& arg : call->args) {
@@ -313,10 +313,10 @@ class MemoryPlanner : public ExprMutator {
         }
         new_args.Set(0, MakeConstant(ScalarValue::make(tensor_groups_.groups[group_id].size)));
         if (new_args.size() == 5) {
-          new_args.push_back(MakeConstant(BoolValue::make(async)));
+          new_args.push_back(MakeConstant(BoolValue::make(alloc_async)));
         } else {
           CHECK_EQ(new_args.size(), 6U);
-          new_args.Set(5, MakeConstant(BoolValue::make(async)));
+          new_args.Set(5, MakeConstant(BoolValue::make(alloc_async)));
         }
         return Call(alloc_storage_op, new_args);
       }

--- a/src/pass/memory_plan.cc
+++ b/src/pass/memory_plan.cc
@@ -305,7 +305,7 @@ class MemoryPlanner : public ExprMutator {
 
       auto group_id = tensor_groups_.FindGroupIdByStorageVar(curr_let_);
       if (group_id != -1 && tensor_groups_.groups[group_id].size > 0) {
-        bool sync = tensor_groups_.HasOutputTensor(group_id);
+        bool async = !tensor_groups_.HasOutputTensor(group_id);
 
         Array<Expr> new_args;
         for (auto& arg : call->args) {
@@ -313,10 +313,10 @@ class MemoryPlanner : public ExprMutator {
         }
         new_args.Set(0, MakeConstant(ScalarValue::make(tensor_groups_.groups[group_id].size)));
         if (new_args.size() == 5) {
-          new_args.push_back(MakeConstant(BoolValue::make(sync)));
+          new_args.push_back(MakeConstant(BoolValue::make(async)));
         } else {
           CHECK_EQ(new_args.size(), 6U);
-          new_args.Set(5, MakeConstant(BoolValue::make(sync)));
+          new_args.Set(5, MakeConstant(BoolValue::make(async)));
         }
         return Call(alloc_storage_op, new_args);
       }


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
In the case of CUDA 11.3, we currently always use AllocSync to allocate memory to CUDA memory pool for better efficiency. However, in the case that allocated tensor becomes the final output, we should not let the CUDA memory pool maintain them to avoid fragmentation issue.

In this PR, we introduce an optional argument, `alloc_async` (`async` becomes a keyword since Python 3.7), to AllocStorage instruction in VM. When it is true (by default), we keep the current semantic of allocating buffers to CUDA memory pool; otherwise we use cuMalloc to allocate a buffer directly from GPU DRAM. This argument will be set by MemoryPlan pass with liveness analysis.

With this PR, Razor can now achieve the same batch size as RAF (i.e., 24) for bert_base_mlm with seq=512, amp, remat.

## Checklist ##

- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @awslabs/raf-reviewer @zhouyuan1119 @yzhliu 
