### PR TITLE
[Bugfix] Fix bug in #28

### DIFF
--- a/src/pass/type_infer.cc
+++ b/src/pass/type_infer.cc
@@ -220,7 +220,8 @@ class TypeInferencer : public ExprMutator {
       try {
         // Try to unify caller type and param type.
         Unify(call->args[i]->checked_type(), curr_fn->params[i]->type_annotation);
-        new_params.push_back(MakeVar(curr_fn->params[i]->name_hint(), curr_fn->params[i]->type_annotation));
+        new_params.push_back(
+            MakeVar(curr_fn->params[i]->name_hint(), curr_fn->params[i]->type_annotation));
       } catch (const dmlc::Error& e) {
         // If caller type and closure parameter type are inconsistent and this is the first caller,
         // update the closure parameter type; othewise throw an error.
@@ -230,7 +231,8 @@ class TypeInferencer : public ExprMutator {
             << raf::ir::AsText(curr_fn) << std::endl
             << e.what();
         update_closure = true;
-        new_params.push_back(MakeVar(curr_fn->params[i]->name_hint(), call->args[i]->checked_type()));
+        new_params.push_back(
+            MakeVar(curr_fn->params[i]->name_hint(), call->args[i]->checked_type()));
       }
     }
 
@@ -245,7 +247,7 @@ class TypeInferencer : public ExprMutator {
       UpdateFuncParamVarMap(curr_fn.as<FunctionNode>(), call->args);
     }
     curr_fn = Downcast<Function>(VisitExpr(curr_fn));
-    
+
     // Mark both the original and updated closure as visited because they are not allowed
     // to be updated anymore.
     visited_closures_[fn] = curr_fn;

--- a/tests/python/pass/test_pass_infer_type.py
+++ b/tests/python/pass/test_pass_infer_type.py
@@ -426,11 +426,13 @@ def test_closure_param_type_update():
             hit_count += 1
             assert line.find("ty=(Tensor[(10, 10), float32], float32, uint8") != -1
         elif (
+            # pylint: disable=line-too-long
             line.find(
                 'fn (%p0: (Tensor[(10, 10), float32], float32, uint8, Tensor[(13), uint8]), %p1: (int32,), %p2: int64, Primitive=1, Dialect="tvm") -> Tensor[(100), float16]'
             )
             != -1
-        ):  # pylint: disable=line-too-long
+            # pylint: enable=line-too-long
+        ):
             # Should hit 1 time if the closure is reused
             hit_count += 1
             assert line.find("Tensor[(10, 10), float32], float32, uint8") != -1

--- a/tests/python/pass/test_pass_infer_type.py
+++ b/tests/python/pass/test_pass_infer_type.py
@@ -436,7 +436,7 @@ def test_closure_param_type_update():
             # Should hit 1 time if the closure is reused
             hit_count += 1
             assert line.find("Tensor[(10, 10), float32], float32, uint8") != -1
-    assert hit_count == 3
+    assert hit_count == 3, "Unexpected {hit_count}: %s" % raf.ir.AsText(mod)
 
 
 def test_multi_functions():


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
In #28 I forgot to add the updated closure to the visit closure list. As a result, InferType throws an error even a closure is used by two callers with the same type.

## Checklist ##

- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @awslabs/raf-reviewer @yzhliu @hgt312 
