### PR TITLE
[VM] Cache fused func JIT

### DIFF
--- a/src/op/dialect/cutlass/conv.cc
+++ b/src/op/dialect/cutlass/conv.cc
@@ -96,14 +96,14 @@ void CutlassConv2dOpEnv::Init(const CallValues& cv) {
 }
 
 OpEnv* CutlassConv2dOpEnv::make(const CallValues& cv) {
-  std::unique_ptr<CutlassConv2dOpEnv> op_env(std::make_unique<CutlassConv2dOpEnv>(cv));
+  CutlassConv2dOpEnv* op_env = new CutlassConv2dOpEnv(cv);
   auto matched_pattern = op_env->Pattern(cv);
   auto valid = op_env->IsValid(cv);
   if (!matched_pattern || !valid) {
     std::stringstream ss;
     ss << "[CUTLASS] Cannot JIT: matched pattern? " << matched_pattern << ", valid? " << valid;
     op_env->error_msgs.push_back(ss.str());
-    return op_env.release();
+    return op_env;
   }
   try {
     op_env->Init(cv);
@@ -111,9 +111,9 @@ OpEnv* CutlassConv2dOpEnv::make(const CallValues& cv) {
     std::stringstream ss;
     ss << "[CUTLASS] Failed to JIT: " << e.what();
     op_env->error_msgs.push_back(ss.str());
-    return op_env.release();
+    return op_env;
   }
-  return op_env.release();
+  return op_env;
 }
 
 void CutlassConv2dOpEnv::Execute(const std::vector<Value>& inputs, Value output) {

--- a/src/op/dialect/cutlass/conv_utils.cc
+++ b/src/op/dialect/cutlass/conv_utils.cc
@@ -25,7 +25,7 @@ void CutlassConvOpEnv::InitConvOperation(
 
   int Q = (W + 2 * pad_w - ((S - 1) * dilation_w + 1)) / stride_w + 1;
 
-  functional_key_ = std::make_unique<ConvFunctionalKeyExt>(
+  functional_key_ = std::make_shared<ConvFunctionalKeyExt>(
       provider_, ConvKind::kFprop, element_A, layout_A, element_B, layout_B, element_C, layout_A,
       element_accumulator, element_compute, epilogue_math_op);
 
@@ -35,7 +35,7 @@ void CutlassConvOpEnv::InitConvOperation(
   CHECK(!operators_it->second.empty());
 
   preference_key_ =
-      std::make_unique<ConvPreferenceKey>(compute_capability(), IteratorAlgorithmID::kOptimized);
+      std::make_shared<ConvPreferenceKey>(compute_capability(), IteratorAlgorithmID::kOptimized);
 
   Operation const* operation =
       find_conv2d_operation(operators_it, *preference_key_, preferred_name);
@@ -74,7 +74,7 @@ void CutlassConvOpEnv::InitConvOperation(
   };
 }
 
-std::vector<std::unique_ptr<TunableConfig>> CutlassConvOpEnv::ListTunableConfigs() {
+std::vector<std::shared_ptr<TunableConfig>> CutlassConvOpEnv::ListTunableConfigs() {
   // Tunable configuration: kernel_name
   std::vector<std::string> kernel_names;
   auto operators_it = SingletonExt::get().operation_table.conv2d_operations.find(*functional_key_);
@@ -94,14 +94,14 @@ std::vector<std::unique_ptr<TunableConfig>> CutlassConvOpEnv::ListTunableConfigs
       }
     }
   }
-  std::vector<std::unique_ptr<TunableConfig>> rets;
+  std::vector<std::shared_ptr<TunableConfig>> rets;
   for (const auto& name : kernel_names) {
-    rets.push_back(std::make_unique<ConvTunableConfig>(name));
+    rets.push_back(std::make_shared<ConvTunableConfig>(name));
   }
   return rets;
 }
 
-void CutlassConvOpEnv::SetTunableConfig(const std::unique_ptr<TunableConfig>& tunable) {
+void CutlassConvOpEnv::SetTunableConfig(const std::shared_ptr<TunableConfig>& tunable) {
   tunable_ = *static_cast<ConvTunableConfig*>(tunable.get());
 }
 

--- a/src/op/dialect/cutlass/conv_utils.h
+++ b/src/op/dialect/cutlass/conv_utils.h
@@ -35,9 +35,9 @@ class CutlassConvOpEnv : public CutlassOpEnv {
   explicit CutlassConvOpEnv(const CallValues& call) : CutlassOpEnv(call) {
   }
 
-  std::vector<std::unique_ptr<TunableConfig>> ListTunableConfigs() override;
+  std::vector<std::shared_ptr<TunableConfig>> ListTunableConfigs() override;
 
-  void SetTunableConfig(const std::unique_ptr<TunableConfig>& tunable) override;
+  void SetTunableConfig(const std::shared_ptr<TunableConfig>& tunable) override;
 
   /*!
    * \brief Initialize a convolution operator
@@ -85,9 +85,9 @@ class CutlassConvOpEnv : public CutlassOpEnv {
   /*! \brief Convolution operator arguments */
   ConvArguments arguments_;
   /*! \brief Conv functional key */
-  std::unique_ptr<ConvFunctionalKeyExt> functional_key_;
+  std::shared_ptr<ConvFunctionalKeyExt> functional_key_;
   /*! \brief Conv functional key */
-  std::unique_ptr<ConvPreferenceKey> preference_key_;
+  std::shared_ptr<ConvPreferenceKey> preference_key_;
   /*! \brief Tunable configuration for cutlass conv */
   ConvTunableConfig tunable_;
 };

--- a/src/op/dialect/cutlass/cutlass_fusion.cc
+++ b/src/op/dialect/cutlass/cutlass_fusion.cc
@@ -9,6 +9,7 @@
  */
 #include <limits>
 
+#include "raf/cache.h"
 #include "raf/value.h"
 #include "raf/profiler.h"
 #include "raf/registry.h"
@@ -30,23 +31,69 @@ using namespace raf::ir;
 using namespace raf::value;
 using raf::registry::TypedPackedFunc;
 
+/*! \brief The persist cache entry of the best CUTLASS tuned config. */
+class CUTLASSConfigCacheEntry {
+ public:
+  explicit CUTLASSConfigCacheEntry() {
+  }
+
+  CUTLASSConfigCacheEntry(std::shared_ptr<TunableConfig> config) : config_(config) {
+  }
+
+  std::shared_ptr<TunableConfig> GetConfig() {
+    return config_;
+  }
+
+  static CUTLASSConfigCacheEntry Load(const std::string path) {
+    // Not support deserialization yet.
+    throw;
+  }
+
+  bool Save(const std::string& path) {
+    // Not support serialization yet.
+    return false;
+  }
+
+ private:
+  /*! \brief The tunable config. */
+  std::shared_ptr<TunableConfig> config_;
+};
+
+MetaPersistCache<CUTLASSConfigCacheEntry> CacheConfig("cutlass_fusion_config");
+
+HashKey HashFusedFunc(const Function& func) {
+  HashKey key;
+  key << raf::ir::AsText(func, true);
+  return key;
+}
+
 OpEnv* Tune(const op::CallValues& call, OpEnv* op_env) {
   CutlassOpEnv* env = static_cast<CutlassOpEnv*>(op_env);
-  std::vector<std::unique_ptr<TunableConfig>> tunable = env->ListTunableConfigs();
-  const int number = 10, repeat = 1, min_repeat_ms = 0;
-  std::unique_ptr<TunableConfig> best;
-  double min_time = std::numeric_limits<double>::max();
-  for (auto& i : tunable) {
-    env->SetTunableConfig(i);
-    env->Init(call);
-    Array<FloatValue> result = TimeEvaluator(TypedPackedFunc<void()>([&]() { env->Execute(call); }),
-                                             call->device, number, repeat, min_repeat_ms)();
-    CHECK_EQ(result.size(), 1U);
-    if (result[0]->value < min_time) {
-      min_time = result[0]->value;
-      best = std::move(i);
+  auto key = HashFusedFunc(Downcast<ClosureValue>(call->callee)->func);
+  std::shared_ptr<TunableConfig> best;
+
+  if (const auto* compiled = CacheConfig.Get(key.byte_vector)) {
+    CUTLASSConfigCacheEntry entry = *compiled;
+    best = entry.GetConfig();
+  } else {
+    std::vector<std::shared_ptr<TunableConfig>> tunable = env->ListTunableConfigs();
+    const int number = 10, repeat = 1, min_repeat_ms = 0;
+    double min_time = std::numeric_limits<double>::max();
+    for (auto& config : tunable) {
+      env->SetTunableConfig(config);
+      env->Init(call);
+      Array<FloatValue> result =
+          TimeEvaluator(TypedPackedFunc<void()>([&]() { env->Execute(call); }), call->device,
+                        number, repeat, min_repeat_ms)();
+      CHECK_EQ(result.size(), 1U);
+      if (result[0]->value < min_time) {
+        min_time = result[0]->value;
+        best = config;
+      }
     }
+    CacheConfig.Set(key.byte_vector, CUTLASSConfigCacheEntry(best));
   }
+
   env->SetTunableConfig(best);
   env->Init(call);
   return env;

--- a/src/op/dialect/cutlass/cutlass_fusion.cc
+++ b/src/op/dialect/cutlass/cutlass_fusion.cc
@@ -63,7 +63,7 @@ MetaPersistCache<CUTLASSConfigCacheEntry> CacheConfig("cutlass_fusion_config");
 
 HashKey HashFusedFunc(const Function& func) {
   HashKey key;
-  key << raf::ir::AsText(func, true);
+  key << tvm::AsText(func, true);
   return key;
 }
 

--- a/src/op/dialect/cutlass/cutlass_utils.cc
+++ b/src/op/dialect/cutlass/cutlass_utils.cc
@@ -46,7 +46,7 @@ void CutlassOpEnv::RequestWorkspace(void** dest, const Device& device, int64_t n
   *dest = workspace_mem_->data;
 }
 
-std::ostream& operator<<(std::ostream& stream, const std::unique_ptr<TunableConfig>& config) {
+std::ostream& operator<<(std::ostream& stream, const std::shared_ptr<TunableConfig>& config) {
   config->AsText(stream);
   return stream;
 }

--- a/src/op/dialect/cutlass/cutlass_utils.h
+++ b/src/op/dialect/cutlass/cutlass_utils.h
@@ -53,10 +53,10 @@ class CutlassOpEnv : public raf::op::OpEnv {
   void RequestWorkspace(void** dest, const Device& device, int64_t nbytes);
 
   /*! \brief Set tunable configuration */
-  virtual void SetTunableConfig(const std::unique_ptr<TunableConfig>& tunable) = 0;
+  virtual void SetTunableConfig(const std::shared_ptr<TunableConfig>& tunable) = 0;
 
   /*! \brief List all possible configs */
-  virtual std::vector<std::unique_ptr<TunableConfig>> ListTunableConfigs() = 0;
+  virtual std::vector<std::shared_ptr<TunableConfig>> ListTunableConfigs() = 0;
 
   /*! \brief Initialize with default configuration */
   virtual void Init(const CallValues& call) = 0;
@@ -111,7 +111,7 @@ struct TunableConfig {
   std::string kernel_name;
 };
 
-std::ostream& operator<<(std::ostream& stream, const std::unique_ptr<TunableConfig>& config);
+std::ostream& operator<<(std::ostream& stream, const std::shared_ptr<TunableConfig>& config);
 
 std::ostream& operator<<(std::ostream& stream, const SplitKMode& mode);
 

--- a/src/op/dialect/cutlass/gemm.cc
+++ b/src/op/dialect/cutlass/gemm.cc
@@ -185,14 +185,14 @@ void CutlassMatmulOpEnv::Init(const CallValues& cv) {
 }
 
 OpEnv* CutlassMatmulOpEnv::make(const CallValues& cv) {
-  std::unique_ptr<CutlassMatmulOpEnv> op_env(std::make_unique<CutlassMatmulOpEnv>(cv));
+  CutlassMatmulOpEnv* op_env = new CutlassMatmulOpEnv(cv);
   auto matched_pattern = op_env->Pattern(cv);
   auto valid = op_env->IsValid(cv);
   if (!matched_pattern || !valid) {
     std::stringstream ss;
     ss << "[CUTLASS] Cannot JIT: matched pattern? " << matched_pattern << ", valid? " << valid;
     op_env->error_msgs.push_back(ss.str());
-    return op_env.release();
+    return op_env;
   }
   try {
     op_env->Init(cv);
@@ -200,9 +200,9 @@ OpEnv* CutlassMatmulOpEnv::make(const CallValues& cv) {
     std::stringstream ss;
     ss << "[CUTLASS] Failed to JIT: " << e.what();
     op_env->error_msgs.push_back(ss.str());
-    return op_env.release();
+    return op_env;
   }
-  return op_env.release();
+  return op_env;
 }
 
 void CutlassMatmulOpEnv::Execute(const std::vector<Value>& inputs, Value output) {

--- a/src/op/dialect/cutlass/gemm_utils.cc
+++ b/src/op/dialect/cutlass/gemm_utils.cc
@@ -23,7 +23,7 @@ void CutlassGemmOpEnv::InitGemmOperation(
     int ldd, int batch_count, int64_t batch_stride_A, int64_t batch_stride_B,
     int64_t batch_stride_C, int64_t batch_stride_D, EpilogueKindExt epilogue_math_op,
     const std::string& preferred_name) {
-  functional_key_ = std::make_unique<GemmFunctionalKeyExt>(
+  functional_key_ = std::make_shared<GemmFunctionalKeyExt>(
       provider_, GemmKind::kUniversal, element_compute, element_scalar, element_A, layout_A,
       ComplexTransform::kNone, element_B, layout_B, ComplexTransform::kNone, element_C,
       epilogue_math_op);
@@ -51,7 +51,7 @@ void CutlassGemmOpEnv::InitGemmOperation(
                                          ptr_D_check, ldd, 0, kMaximumAlignmentSize);
 
   // Find the best kernel in descending order of preference.
-  preference_key_ = std::make_unique<GemmPreferenceKey>(compute_capability(), alignment);
+  preference_key_ = std::make_shared<GemmPreferenceKey>(compute_capability(), alignment);
   Operation const* operation = find_gemm_operation(operators_it, *preference_key_, preferred_name);
   CHECK(operation);
   operation_ = operation;
@@ -84,7 +84,7 @@ void CutlassGemmOpEnv::InitGemmOperation(
                                       batch_stride_D};
 }
 
-std::vector<std::unique_ptr<TunableConfig>> CutlassGemmOpEnv::ListTunableConfigs() {
+std::vector<std::shared_ptr<TunableConfig>> CutlassGemmOpEnv::ListTunableConfigs() {
   // Tunable configuration: split_k_slices
   // Split axis k into 1 slice (no slicing) or 4 slices
   const static std::vector<int> split_k_slices = {1, 2, 4, 8};
@@ -112,18 +112,18 @@ std::vector<std::unique_ptr<TunableConfig>> CutlassGemmOpEnv::ListTunableConfigs
       }
     }
   }
-  std::vector<std::unique_ptr<TunableConfig>> rets;
+  std::vector<std::shared_ptr<TunableConfig>> rets;
   for (const auto& name : kernel_names) {
     for (const auto& i_split_k_slices : split_k_slices) {
       for (const auto& i_split_k_mode : split_k_mode) {
-        rets.push_back(std::make_unique<GemmTunableConfig>(name, i_split_k_mode, i_split_k_slices));
+        rets.push_back(std::make_shared<GemmTunableConfig>(name, i_split_k_mode, i_split_k_slices));
       }
     }
   }
   return rets;
 }
 
-void CutlassGemmOpEnv::SetTunableConfig(const std::unique_ptr<TunableConfig>& tunable) {
+void CutlassGemmOpEnv::SetTunableConfig(const std::shared_ptr<TunableConfig>& tunable) {
   tunable_ = *static_cast<GemmTunableConfig*>(tunable.get());
 }
 

--- a/src/op/dialect/cutlass/gemm_utils.h
+++ b/src/op/dialect/cutlass/gemm_utils.h
@@ -43,9 +43,9 @@ class CutlassGemmOpEnv : public CutlassOpEnv {
   explicit CutlassGemmOpEnv(const CallValues& call) : CutlassOpEnv(call) {
   }
 
-  std::vector<std::unique_ptr<TunableConfig>> ListTunableConfigs() override;
+  std::vector<std::shared_ptr<TunableConfig>> ListTunableConfigs() override;
 
-  void SetTunableConfig(const std::unique_ptr<TunableConfig>& tunable) override;
+  void SetTunableConfig(const std::shared_ptr<TunableConfig>& tunable) override;
 
   /*!
    * \brief Initialize a gemm operator
@@ -94,9 +94,9 @@ class CutlassGemmOpEnv : public CutlassOpEnv {
   /*! \brief Gemm operator arguments */
   GemmUniversalArguments arguments_;
   /*! \brief Gemm functional key */
-  std::unique_ptr<GemmFunctionalKeyExt> functional_key_;
+  std::shared_ptr<GemmFunctionalKeyExt> functional_key_;
   /*! \brief Gemm functional key */
-  std::unique_ptr<GemmPreferenceKey> preference_key_;
+  std::shared_ptr<GemmPreferenceKey> preference_key_;
   /*! \brief Tunable configuration for cutlass gemm */
   GemmTunableConfig tunable_;
 };

--- a/src/op/dialect/tvm/tvm_fusion.cc
+++ b/src/op/dialect/tvm/tvm_fusion.cc
@@ -173,9 +173,9 @@ class Cast2TVMDialect : public ExprMutator {
  * \brief Converter from raf style (all inputs are arguments) to
  *        tvm style (inputs are explicitly marked as arguments or attrs)
  */
-class Meta2TVM : public ExprMutator {
+class RAF2TVM : public ExprMutator {
  public:
-  Meta2TVM(const CallValues& call, const DevType& dev_type)
+  RAF2TVM(const CallValues& call, const DevType& dev_type)
       : func_(Downcast<ClosureValue>(call->callee)->func),
         call_values_getter_(call),
         device_type_(dev_type) {
@@ -251,26 +251,56 @@ class Meta2TVM : public ExprMutator {
   DevType device_type_;
 };
 
+HashKey HashFusedFunc(const Function& func) {
+  HashKey key;
+  key << raf::ir::AsText(func, true);
+  return key;
+}
+
 OpEnv* FusedFuncBuild(const op::CallValues& call) {
   tvm::relay::tec::TECompiler te_compiler;
   auto env = std::make_unique<TVMOpEnv>();
   Device dev = call->device;
+
+  // Determine cache
+  MetaPersistCache<TVMModuleCacheEntry>* cache;
+  if (dev.device_type() == DevType::kCPU()) {
+    cache = &CacheBuildCpu;
+  } else if (dev.device_type() == DevType::kCUDA()) {
+    cache = &CacheBuildCuda;
+  } else {
+    LOG(FATAL) << "NotImplementedError: device is not supported " << dev.device_type().c_str();
+    throw;
+  }
+
   tvm::Target target = dev.tvm_target();
   CHECK(dev.device_type() == DevType::kCPU() || dev.device_type() == DevType::kCUDA())
       << "NotImplementedError: target is not supported " << dev.device_type().c_str();
-  Meta2TVM meta_to_tvm(call, dev.device_type());
-  Function func = Downcast<Function>(meta_to_tvm());
-  // TODO(@hzfan): add cache for raf
-  te_compiler->Clear();
-  env->env_name = TruncateName(GetUniqueName(meta_to_tvm.func_name));
-  try {
-    env->f = te_compiler->JIT(tvm::relay::tec::CCacheKey(func, target));
-  } catch (const dmlc::Error& e) {
-    if (!AllowJitFailure()) {
-      LOG(FATAL) << "Failed to build a fused op " << env->env_name << ": " << e.what();
+  RAF2TVM raf_to_tvm(call, dev.device_type());
+  Function func = Downcast<Function>(raf_to_tvm());
+  env->env_name = TruncateName(GetUniqueName(raf_to_tvm.func_name));
+
+  auto key = HashFusedFunc(func);
+  TVMModuleCacheEntry entry;
+  if (const auto* compiled = cache->Get(key.byte_vector)) {
+    entry = *compiled;
+  } else {
+    te_compiler->Clear();
+    try {
+      auto cached_key = tvm::relay::tec::CCacheKey(func, target);
+      auto cached_func = te_compiler->Lower(cached_key, [](String name) { return name; });
+      auto mod = tvm::build(cached_func->funcs, cached_key->target, Target(nullptr));
+      entry = TVMModuleCacheEntry(mod, cached_func->prim_fn_var->name_hint);
+      cache->Set(key.byte_vector, entry);
+    } catch (const dmlc::Error& e) {
+      if (!AllowJitFailure()) {
+        LOG(FATAL) << "Failed to build a fused op " << env->env_name << ": " << e.what();
+      }
     }
   }
-  env->arg_indices = meta_to_tvm.arg_indices;
+
+  env->f = entry.GetFunction();
+  env->arg_indices = raf_to_tvm.arg_indices;
   Array<Value> args = GetListArgs(call->args);
   for (const int& i : env->arg_indices) {
     GetDLTensor(args[i], &env->inputs);
@@ -299,8 +329,8 @@ float CalcFuncGFLOPS(const op::CallValues& call, const Array<Type>& param_types,
   new_call->out = call->out;
   new_call->device = call->device;
 
-  Meta2TVM meta_to_tvm(new_call, device.device_type());
-  Function tvm_func = Downcast<Function>(meta_to_tvm());
+  RAF2TVM raf_to_tvm(new_call, device.device_type());
+  Function tvm_func = Downcast<Function>(raf_to_tvm());
   tvm::Target target = device.tvm_target();
 
   auto cache_key = tvm::relay::tec::CCacheKey(tvm_func, target);

--- a/src/op/dialect/tvm/tvm_fusion.cc
+++ b/src/op/dialect/tvm/tvm_fusion.cc
@@ -280,7 +280,7 @@ OpEnv* FusedFuncBuild(const op::CallValues& call) {
   Function func = Downcast<Function>(raf_to_tvm());
   env->env_name = TruncateName(GetUniqueName(raf_to_tvm.func_name));
 
-  auto key = HashFusedFunc(func);
+  auto key = HashFusedFunc(Downcast<ClosureValue>(call->callee)->func);
   TVMModuleCacheEntry entry;
   if (const auto* compiled = cache->Get(key.byte_vector)) {
     entry = *compiled;

--- a/src/op/dialect/tvm/tvm_fusion.cc
+++ b/src/op/dialect/tvm/tvm_fusion.cc
@@ -253,7 +253,7 @@ class RAF2TVM : public ExprMutator {
 
 HashKey HashFusedFunc(const Function& func) {
   HashKey key;
-  key << raf::ir::AsText(func, true);
+  key << tvm::AsText(func, true);
   return key;
 }
 


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
Add cache to fused function JITing to reduce the first iteration latency. Specifically, this PR adds two caches for TVM fusion and CUTLASS fusion. Here is the elapsed time of warmup GPT2 on g4.4xl:

|Mode|Time (s)|
--|--
No Cache|483
+Cache TVM fusion|126
+Cache CUTLASS fusion|63

Since we are caching a fused function, I simply use `AsText(func, true)` as the cache key, which includes parameter, output types, and function body.

## Checklist ##

- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @awslabs/raf-reviewer @hzfan 
