### PR TITLE
[Remat] Do not recompute non-deterministic ops

### DIFF
--- a/include/raf/op_utils.h
+++ b/include/raf/op_utils.h
@@ -125,6 +125,12 @@ inline bool IsReshapeOp(const Op& op) {
   return IsInOpSet(op, reshape_ops);
 }
 
+inline bool IsNonDeterministicOp(const Op& op) {
+  static std::unordered_set<Op, ObjectPtrHash, ObjectPtrEqual> non_deterministic_ops{
+      Op::Get("raf.op._contrib_dropout")};
+  return IsInOpSet(op, non_deterministic_ops);
+}
+
 inline bool IsMemcpyOp(const Expr& op) {
   static OpSet memcpy_ops = {
       Op::Get("raf.op.fuse_tensor"),


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
Non-deterministic ops such as dropout cannot be recomputed; otherwise we may get incorrect results.

## Checklist ##

- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @awslabs/raf-reviewer @zhouyuan1119 
