### PR TITLE
[Bugfix] Cache fusion JIT / serialization

### DIFF
--- a/src/impl/ir_ext.cc
+++ b/src/impl/ir_ext.cc
@@ -71,7 +71,7 @@ ObjectRef ConstantExtractValue(RelayConstant _node) {
   return node->value;
 }
 
-Var MakeVar_(Id vid, Type type_annotation, Var may_share = Var()) {
+Var MakeVar_(Id vid, Type type_annotation, Var may_share) {
   ObjectPtr<ExtendedVarNode> n = make_object<ExtendedVarNode>();
   n->vid = std::move(vid);
   n->type_annotation = std::move(type_annotation);

--- a/src/impl/serialization.cc
+++ b/src/impl/serialization.cc
@@ -212,18 +212,18 @@ Value DeserializeValue(dmlc::Stream* strm) {
     }
     case kOpValue: {
       strm->Read(&str);
-      Op op = Downcast<Op>(tvm::LoadJSON(str));
+      Op op = Downcast<Op>(serialization::LoadJSON(str));
       return OpValue::make(op);
     }
     case kClosureValue: {
       strm->Read(&str);
-      auto func = Downcast<Function>(tvm::LoadJSON(str));
+      auto func = Downcast<Function>(serialization::LoadJSON(str));
       uint64_t cnt;
       std::unordered_map<Var, Value, ObjectPtrHash, ObjectPtrEqual> env;
       strm->Read(&cnt);
       for (uint64_t i = 0; i < cnt; ++i) {
         strm->Read(&str);
-        Var var = Downcast<Var>(tvm::LoadJSON(str));
+        Var var = Downcast<Var>(serialization::LoadJSON(str));
         Value val = DeserializeValue(strm);
         env.emplace(var, val);
       }

--- a/src/op/dialect/cutlass/cutlass_fusion.cc
+++ b/src/op/dialect/cutlass/cutlass_fusion.cc
@@ -63,7 +63,7 @@ MetaPersistCache<CUTLASSConfigCacheEntry> CacheConfig("cutlass_fusion_config");
 
 HashKey HashFusedFunc(const Function& func) {
   HashKey key;
-  key << tvm::AsText(func, true);
+  key << raf::ir::AsText(func, true);
   return key;
 }
 

--- a/src/op/dialect/tvm/tvm_fusion.cc
+++ b/src/op/dialect/tvm/tvm_fusion.cc
@@ -253,7 +253,7 @@ class RAF2TVM : public ExprMutator {
 
 HashKey HashFusedFunc(const Function& func) {
   HashKey key;
-  key << tvm::AsText(func, true);
+  key << raf::ir::AsText(func, true);
   return key;
 }
 


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
- Use `raf::ir::AsText` as the fused function key to make sure all values (including constant arguments) are considered.
- Fix a bug in VM deserialization that mis-uses TVM JSON decoder which doesn't use ExtendedVar.

## Checklist ##

- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @awslabs/raf-reviewer @zachzzc @hzfan 
