### PR TITLE
[Fix] Path clearing for Razor distributed execution on GPU

### DIFF
--- a/include/raf/communicator.h
+++ b/include/raf/communicator.h
@@ -108,8 +108,8 @@ class CommunicatorPool {
   }
 
   static CommunicatorPool* Get() {
-    static CommunicatorPool* instance = dmlc::ThreadLocalStore<CommunicatorPool>::Get();
-    return instance;
+    static CommunicatorPool instance;
+    return &instance;
   }
 
   Communicator GetCommunicator(const std::string& name, const Value rank_list) {

--- a/src/device_api/cuda/cuda.cc
+++ b/src/device_api/cuda/cuda.cc
@@ -35,6 +35,7 @@ class CUDADeviceAPI final : public DeviceAPI {
   }
 
   void* AllocMemory(int64_t nbytes, int64_t alignment) override {
+    CUDA_CALL(cudaSetDevice(device_id_));
     void* ptr = nullptr;
     // TODO(@junrushao1994): make sure it is correct
     CHECK_EQ(512 % alignment, 0);
@@ -49,6 +50,7 @@ class CUDADeviceAPI final : public DeviceAPI {
 #if CUDA_VERSION >= 11030
   void SetDevice(const int dev_id) override {
     device_id_ = dev_id;
+    CUDA_CALL(cudaSetDevice(dev_id));
   }
 
   static cudaMemPool_t GetCUDAMemoryPool(int dev_id) {

--- a/src/distributed/common/communicator.cc
+++ b/src/distributed/common/communicator.cc
@@ -119,8 +119,8 @@ class GlobalCommunicatorEntry {
   GlobalCommunicatorEntry() = default;
 
   static GlobalCommunicatorEntry* ThreadLocal() {
-    using TLS = dmlc::ThreadLocalStore<GlobalCommunicatorEntry>;
-    return TLS::Get();
+    static GlobalCommunicatorEntry entry;
+    return &entry;
   }
   Communicator comm;
 };

--- a/src/distributed/common/communicator.cc
+++ b/src/distributed/common/communicator.cc
@@ -118,7 +118,7 @@ class GlobalCommunicatorEntry {
  public:
   GlobalCommunicatorEntry() = default;
 
-  static GlobalCommunicatorEntry* ThreadLocal() {
+  static GlobalCommunicatorEntry* Get() {
     static GlobalCommunicatorEntry entry;
     return &entry;
   }
@@ -126,7 +126,7 @@ class GlobalCommunicatorEntry {
 };
 
 Communicator GetGlobalCommunicator() {
-  auto entry = GlobalCommunicatorEntry::ThreadLocal();
+  auto entry = GlobalCommunicatorEntry::Get();
   if (!entry->comm.defined()) {
 #ifdef RAF_USE_MPI
     Communicator comm = Communicator::Get("mpi");
@@ -139,7 +139,7 @@ Communicator GetGlobalCommunicator() {
 }
 
 void SetDefaultCommunicator(std::string name) {
-  auto entry = GlobalCommunicatorEntry::ThreadLocal();
+  auto entry = GlobalCommunicatorEntry::Get();
   entry->comm = Communicator::Get(name);
 }
 

--- a/src/distributed/cuda/nccl_communicator.cc
+++ b/src/distributed/cuda/nccl_communicator.cc
@@ -112,6 +112,8 @@ NCCLCommunicator NCCLCommunicator::make(Value rank_list) {
   } else {
     // Create Sub-communicator
     InitSubCommunicator(obj.get(), rank_list, global_comm);
+    cudaSetDevice(global_comm->local_rank);
+
     obj->parent_comm = global_comm;
 
     // sync NCCL id between ranks

--- a/src/op/dialect/nccl/nccl.cc
+++ b/src/op/dialect/nccl/nccl.cc
@@ -198,7 +198,7 @@ class NCCLAllGather : public NCCLOpEnv {
 RAF_REGISTER_DIALECT_OP(nccl, _allgather, 10);
 RAF_OP_ENV_MAKER("raf.op.nccl._allgather", NCCLAllGather::make);
 
-class NCCLGroupAllGather : NCCLOpEnv {
+class NCCLGroupAllGather : public NCCLOpEnv {
   explicit NCCLGroupAllGather(const CallValues& cv) : NCCLOpEnv(cv) {
     auto op = ir::Op::Get("raf.op._group_allgather");
     auto fschema_index = ir::Op::GetAttrMap<op::FRAFSchemaFieldIndex>("FRAFSchemaFieldIndex");
@@ -250,7 +250,7 @@ class NCCLGroupAllGather : NCCLOpEnv {
 RAF_REGISTER_DIALECT_OP(nccl, _group_allgather, 10);
 RAF_OP_ENV_MAKER("raf.op.nccl._group_allgather", NCCLGroupAllGather::make);
 
-class NCCLReduceScatter : NCCLOpEnv {
+class NCCLReduceScatter : public NCCLOpEnv {
   void* in_buffer;
   size_t size_in_bytes;
   size_t size;
@@ -334,7 +334,7 @@ class NCCLReduceScatter : NCCLOpEnv {
 RAF_REGISTER_DIALECT_OP(nccl, _reduce_scatter, 10);
 RAF_OP_ENV_MAKER("raf.op.nccl._reduce_scatter", NCCLReduceScatter::make);
 
-class NCCLGroupReduceScatter : NCCLOpEnv {
+class NCCLGroupReduceScatter : public NCCLOpEnv {
   std::vector<size_t> sizes;
   ncclRedOp_t compute;
 


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
These are the fixes to run distributed CUDA by Razor. In Razor, it uses multi-processes for different ranks, but each rank contains multiple threads(one for trace/compile and others for execution). This requires some changes in RAF. To be more specific, 

1) Communicator Pool and entry needs to be shared within the process. Since we mostly do multiprocessing instead of multithreading for distributed training, I removed the thread local version directly. Let me know if you think we should keep the thread-local version.

2) CUDA needs to call cudaSetDevice for each **THREAD** (both trace/compile and executions threads in Razor), if we use cudaMalloc without specified stream. The memory pool is created in trace/compile thread so I add a device setup before Alloc and NCCL call.

## Checklist ##

- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @awslabs/raf-reviewer @comaniac @hgt312 @hzfan @Tonny-Gu @zhen-jia 
