### PR TITLE
[Op] Fix power_dx

### DIFF
--- a/src/op/from_relay/nn.cc
+++ b/src/op/from_relay/nn.cc
@@ -197,24 +197,13 @@ RAF_OP_FROM_RELAY("nn.pad", "raf.op.pad",
                     return raf_args;
                   });
 
-// RAF_OP_FROM_RELAY("nn.dropout", "raf.op._contrib_dropout",
-//                   [&](const Attrs& attrs, const Array<Expr>& args, const VarValueMap& val_map) {
-//                     Array<Expr> raf_args = args;
-//                     const auto* relay_attrs = attrs.as<DropoutAttrs>();
-//                     raf_args.push_back(MakeConstant(ScalarValue::make(relay_attrs->rate)));
-//                     return raf_args;
-//                   });
-RELAY_REGISTER_OP("nn.dropout")
-    .set_attr<op::FRAFFromRelay>("FRAFFromRelay", [](const Attrs& attrs, const Array<Expr>& args,
-                                                     const VarValueMap& val_map) {
-      LOG(WARNING) << "nn.dropout is unavailable in RAF, ignored";
-      const auto* relay_attrs = attrs.as<DropoutAttrs>();
-
-      Array<Expr> ret;
-      ret.push_back(args[0]);
-      ret.push_back(MakeConstant(ScalarValue::make(2)));
-      return Tuple(std::move(ret));
-    });
+RAF_OP_FROM_RELAY("nn.dropout", "raf.op._contrib_dropout",
+                  [&](const Attrs& attrs, const Array<Expr>& args, const VarValueMap& val_map) {
+                    Array<Expr> raf_args = args;
+                    const auto* relay_attrs = attrs.as<DropoutAttrs>();
+                    raf_args.push_back(MakeConstant(ScalarValue::make(relay_attrs->rate)));
+                    return raf_args;
+                  });
 
 }  // namespace from_relay
 }  // namespace op

--- a/src/op/from_relay/nn.cc
+++ b/src/op/from_relay/nn.cc
@@ -197,13 +197,24 @@ RAF_OP_FROM_RELAY("nn.pad", "raf.op.pad",
                     return raf_args;
                   });
 
-RAF_OP_FROM_RELAY("nn.dropout", "raf.op._contrib_dropout",
-                  [&](const Attrs& attrs, const Array<Expr>& args, const VarValueMap& val_map) {
-                    Array<Expr> raf_args = args;
-                    const auto* relay_attrs = attrs.as<DropoutAttrs>();
-                    raf_args.push_back(MakeConstant(ScalarValue::make(relay_attrs->rate)));
-                    return raf_args;
-                  });
+// RAF_OP_FROM_RELAY("nn.dropout", "raf.op._contrib_dropout",
+//                   [&](const Attrs& attrs, const Array<Expr>& args, const VarValueMap& val_map) {
+//                     Array<Expr> raf_args = args;
+//                     const auto* relay_attrs = attrs.as<DropoutAttrs>();
+//                     raf_args.push_back(MakeConstant(ScalarValue::make(relay_attrs->rate)));
+//                     return raf_args;
+//                   });
+RELAY_REGISTER_OP("nn.dropout")
+    .set_attr<op::FRAFFromRelay>("FRAFFromRelay", [](const Attrs& attrs, const Array<Expr>& args,
+                                                     const VarValueMap& val_map) {
+      LOG(WARNING) << "nn.dropout is unavailable in RAF, ignored";
+      const auto* relay_attrs = attrs.as<DropoutAttrs>();
+
+      Array<Expr> ret;
+      ret.push_back(args[0]);
+      ret.push_back(MakeConstant(ScalarValue::make(2)));
+      return Tuple(std::move(ret));
+    });
 
 }  // namespace from_relay
 }  // namespace op

--- a/src/op/grad/binary.cc
+++ b/src/op/grad/binary.cc
@@ -8,6 +8,7 @@
  * \brief Declaration of gradients
  */
 #include "./grad_utils.h"
+#include "raf/op_utils.h"
 
 namespace raf {
 namespace op {
@@ -102,21 +103,28 @@ RAF_OP_GRAD("raf.op.multiply", MulGrad);
 Array<Expr> PowGrad(const Expr& orig_call, const Array<Expr> orig_args, const Var& y,
                     const Expr& dy) {
   static auto op_power = Op::Get("raf.op.power");
+  static auto op_ones_like = Op::Get("raf.op.ones_like");
   static auto op_multiply = Op::Get("raf.op.multiply");
   static auto op_log = Op::Get("raf.op.log");
-  static auto op_divide = Op::Get("raf.op.divide");
+  static auto op_subtract = Op::Get("raf.op.subtract");
   const CallNode* call = orig_call.as<CallNode>();
   CHECK_GE(call->args.size(), 2);
-  const Expr& x1 = call->args[0];
-  const Expr& x2 = call->args[1];
-  Call y1 = Call(op_power, {x1, x2});
-  Call y2 = Call(op_divide, {y1, x1});
-  Call dx1 = Call(op_multiply, {x2, y2});
-  Call x1_log = Call(op_log, {x1});
-  Call dx2 = Call(op_multiply, {y1, x1_log});
+  const Expr& x = call->args[0];
+  const Expr& a = call->args[1];
 
-  return {GetCollapseSumLike(Call(op_multiply, {dy, dx1}), x1),
-          GetCollapseSumLike(Call(op_multiply, {dy, dx2}), x2)};
+  // dx = a * x^(a-1)
+  Call ones = Call(op_ones_like, {a});
+  Call a_minus_one = Call(op_subtract, {a, ones, MakeNull(), MakeNull()});
+  Call x_pow_minus_one = Call(op_power, {x, a_minus_one});
+  Call dx = Call(op_multiply, {a, x_pow_minus_one});
+
+  // da = x^a * log(x)
+  Call x_pow = Call(op_power, {x, a});
+  Call x_log = Call(op_log, {x});
+  Call da = Call(op_multiply, {x_pow, x_log});
+
+  return {GetCollapseSumLike(Call(op_multiply, {dy, dx}), x),
+          GetCollapseSumLike(Call(op_multiply, {dy, da}), a)};
 }
 
 RAF_OP_GRAD("raf.op.power", PowGrad);

--- a/tests/python/op/tvm/test_tvm_binary.py
+++ b/tests/python/op/tvm/test_tvm_binary.py
@@ -71,7 +71,6 @@ def test_binary_ops_without_grad(ops, shape, dtype, device):
     [
         (torch.mul, raf._op.sym.multiply),
         (torch.div, raf._op.sym.divide),
-        (torch.pow, raf._op.sym.power),
         (torch.add, raf._op.sym.add),
         (torch.sub, raf._op.sym.subtract),
     ],
@@ -87,6 +86,24 @@ def test_binary_ops_with_grad(ops, shape, dtype, device):
     t_y.backward(t_dy)
 
     verify_op(m_op, [m_x1, m_x2], device, t_y, m_dy, [t_x1.grad, t_x2.grad])
+
+
+@pytest.mark.parametrize("device", get_testable_devices())
+@pytest.mark.parametrize("dtype", ["float32"])
+def test_power(dtype, device):
+    x1 = np.random.randn(2, 2).astype("float32")
+    x1[0][0] = 0  # Assign 0 to test the corner case.
+    t_x1 = torch.Tensor(x1).to(device)
+    t_x1.requires_grad = True
+    m_x1 = raf.array(x1, device=device)
+    m_x1.requires_grad = True
+
+    m_x2, t_x2 = randn_torch((), dtype=dtype, device=device, requires_grad=True)
+    t_y = torch.pow(t_x1, t_x2)
+    m_dy, t_dy = randn_torch(t_y.shape, dtype=dtype, device=device)
+    t_y.backward(t_dy)
+
+    verify_op(raf._op.sym.power, [m_x1, m_x2], device, t_y, m_dy, [t_x1.grad, t_x2.grad])
 
 
 # logical_and only allows bool input s


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
The current derivation of `y=x^a` is `dx = a * x^a / x`. This is problematic and results in `nan` when `x=0`. This PR changes the logic to `dx = a * x ^ (a-1)` to avoid such case.

## Checklist ##

- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @awslabs/raf-reviewer @yzhliu 
