### PR TITLE
[Autogen] add indent for schema field index if condition in regs.cc

### DIFF
--- a/scripts/src_codegen/main_cxx_reg.py
+++ b/scripts/src_codegen/main_cxx_reg.py
@@ -590,7 +590,7 @@ int {SCHEMA_NAME}(const std::string& field) {{
     schema_name = snake_to_pascal(schema_name)
     args = []
     for i, entry in enumerate(schema):
-        args.append(ARG.format(I=i, FIELD=entry.name))
+        args.append("  " + ARG.format(I=i, FIELD=entry.name))
     args = "\n".join(map(add_no_lint, args))
     return VALUE_TO_SCHEMA.format(SCHEMA_NAME=schema_name, ARGS=args)
 


### PR DESCRIPTION
## Description ##
Fix the code indent, the `strip()` removes the indent in `if` statement.

## Checklist ##

- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @comaniac 
