### PR TITLE
[Op] [TVM] Lightweight TOPI schedule tuner

### DIFF
--- a/python/raf/_tvm_op/reduce.py
+++ b/python/raf/_tvm_op/reduce.py
@@ -226,8 +226,6 @@ def schedule_sum(attrs, outs, target):
 
 @schedule_sum.register(["cuda", "gpu"])
 def schedule_sum_cuda(attrs, outs, target):
-    # pylint: disable=unused-argument
-    # pylint: disable=invalid-name
     def get_num_elements(axes):
         extents = [int(iv.dom.extent) for iv in axes]
         n_elems = 1

--- a/python/raf/_tvm_op/reduce.py
+++ b/python/raf/_tvm_op/reduce.py
@@ -18,253 +18,6 @@ from .utils import profile_schedule
 _topi = _tvm.topi  # pylint: disable=invalid-name, no-member
 
 
-def _schedule_cuda_sum_long_reduce(op, sch, is_idx_reduce=False, **kwargs):
-    # Setup the tunable parameter value.
-    num_thread = kwargs.get("num_thread", 32)
-
-    if is_idx_reduce:
-        data_out = op.input_tensors[0]
-    else:
-        data_out = op.output(0)
-
-    if not sch[data_out].op.reduce_axis:
-        return _topi.cuda.schedule_injective_from_existing(sch, op.output(0))
-
-    if len(sch[data_out].op.axis) > 0:
-        all_reduce = False
-        block_x = _tvm.te.thread_axis("blockIdx.x")
-        thread_x = _tvm.te.thread_axis((0, num_thread), "threadIdx.x")
-        thread_y = _tvm.te.thread_axis((0, num_thread), "threadIdx.y")
-    else:
-        all_reduce = True
-        num_thread = _tvm.target.Target.current(allow_none=False).max_num_threads
-        thread_x = _tvm.te.thread_axis((0, num_thread), "threadIdx.x")
-
-    # Fuse and refactor the reduce axis
-    fused_reduce = sch[data_out].fuse(
-        *[sch[data_out].op.reduce_axis[i] for i in range(len(sch[data_out].op.reduce_axis))]
-    )
-    ko, ki = sch[data_out].split(fused_reduce, factor=num_thread)
-    if is_idx_reduce:
-        data_out_rf, _ = sch.rfactor(data_out, ki)
-    else:
-        data_out_rf = sch.rfactor(data_out, ki)
-    tx = sch[data_out].op.reduce_axis[0]
-    sch[data_out].bind(tx, thread_x)
-    sch[data_out_rf].compute_at(sch[data_out], tx)
-    if is_idx_reduce:
-        real_output = op.output(0)
-        temp_idx_input = data_out.op.output(0)
-        temp_val_input = data_out.op.output(1)
-    else:
-        real_output = data_out
-    if not all_reduce:
-        # Fuse and split the axis
-        fused_outer = sch[real_output].fuse(
-            *[sch[real_output].op.axis[i] for i in range(len(sch[real_output].op.axis))]
-        )
-        bx, outer_in = sch[real_output].split(fused_outer, factor=num_thread)
-
-        # Bind the axes to threads and blocks
-        sch[real_output].bind(outer_in, thread_y)
-        sch[real_output].bind(bx, block_x)
-        if is_idx_reduce:
-            sch[temp_idx_input].compute_at(sch[real_output], outer_in)
-            sch[temp_val_input].compute_at(sch[real_output], outer_in)
-        sch[real_output].set_store_predicate(
-            _tvm.tir.all(
-                thread_x.equal(0), block_x * num_thread + thread_y < reduce(mul, real_output.shape)
-            )
-        )
-    else:
-        if is_idx_reduce:
-            spatial_axis = sch[real_output].fuse(*(sch[real_output].op.axis))
-            sch[real_output].bind(spatial_axis, _tvm.te.thread_axis("blockIdx.x"))
-            sch[temp_idx_input].compute_at(sch[real_output], spatial_axis)
-            sch[temp_val_input].compute_at(sch[real_output], spatial_axis)
-        sch[real_output].set_store_predicate(thread_x.equal(0))
-    return sch
-
-
-def _enable_auto_inline(sch):
-    def is_scheduled(stage):
-        # auto inline requires the attach type is AttachType.kGroupRoot
-        conds = [
-            len(stage.relations) == 0,
-            stage.attach_type == 1,
-            stage.all_iter_vars == stage.leaf_iter_vars,
-        ]
-        if not all(conds):
-            return True
-        return False
-
-    for s in sch.stages:
-        if not s.is_output and isinstance(s.op, _tvm.te.ComputeOp):
-            if is_scheduled(s) or len(s.op.reduce_axis) != 0:
-                return False
-    return True
-
-
-@profile_schedule(num_thread=[8, 16, 32, 64])
-def schedule_cuda_sum_long_reduce(outs, **kwargs):
-    """Schedule for inject->reduce->bcast ops.
-
-    Parameters
-    ----------
-    outs: Array of Tensor
-        The computation graph description of reduce in the format of an array of tensors.
-
-    Returns
-    -------
-    sch: Schedule
-        The computation schedule for the op.
-    """
-    outs = [outs] if isinstance(outs, _tvm.te.tensor.Tensor) else outs
-    sch = _tvm.te.create_schedule([x.op for x in outs])
-    scheduled_ops = []
-    enable_auto_inline = _enable_auto_inline(sch)
-
-    def traverse_before_reduce(tensor):
-        """Internal traverse function"""
-        operator = tensor.op
-        if isinstance(operator, _tvm.te.PlaceholderOp):
-            return
-        if _topi.tag.is_injective(operator.tag):
-            sch[operator].compute_inline()
-            for inp_tensor in operator.input_tensors:
-                if inp_tensor.op not in scheduled_ops:
-                    traverse_before_reduce(inp_tensor)
-        else:
-            raise RuntimeError("Unsupported operator: %s" % operator.tag)
-
-        scheduled_ops.append(operator)
-
-    def traverse_after_reduce(tensor):
-        """Internal traverse function"""
-        operator = tensor.op
-        if _topi.tag.is_broadcast(operator.tag):
-            if operator not in scheduled_ops:
-                _topi.schedule_injective_from_existing(sch, operator.output(0))
-            for inp_tensor in operator.input_tensors:
-                if inp_tensor.op not in scheduled_ops:
-                    if enable_auto_inline:
-                        traverse_before_reduce(inp_tensor)
-                    else:
-                        traverse_after_reduce(inp_tensor)
-        elif operator.tag == "comm_reduce":
-            if operator not in scheduled_ops:
-                _schedule_cuda_sum_long_reduce(operator, sch, is_idx_reduce=False, **kwargs)
-            for inp_tensor in operator.input_tensors:
-                if inp_tensor.op not in scheduled_ops:
-                    traverse_before_reduce(inp_tensor)
-        elif operator.tag == "comm_reduce_idx":
-            if operator not in scheduled_ops:
-                _schedule_cuda_sum_long_reduce(operator, sch, is_idx_reduce=True, **kwargs)
-            input_tensors = operator.input_tensors[0].op.input_tensors
-            for inp_tensor in input_tensors:
-                if inp_tensor.op not in scheduled_ops:
-                    traverse_before_reduce(inp_tensor)
-        elif isinstance(operator, _tvm.te.PlaceholderOp):
-            pass
-        else:
-            raise RuntimeError("Unsupported operator: %s" % operator.tag)
-
-        scheduled_ops.append(operator)
-
-    for out in outs:
-        traverse_after_reduce(out)
-
-    return sch
-
-
-@profile_schedule(num_thread=[16, 32, 64], max_block=[128, 256, 512])
-def schedule_cuda_short_reduce(outs, **kwargs):
-    """Schedule sum as an injective op.
-
-    Parameters
-    ----------
-    outs: Array of Tensor
-          The computation graph description of injective in the format
-          of an array of tensors.
-
-    Returns
-    -------
-    sch: Schedule
-        The computation schedule for the op.
-    """
-    num_thread = kwargs.get(
-        "num_thread", _tvm.target.Target.current(allow_none=False).max_num_threads
-    )
-    max_block = kwargs.get("max_block", 256)
-
-    def find_nearest_small_factor(num, target):
-        """Find the nearest factor of the given number that is smaller than the target."""
-        for i in range(target, 0, -1):
-            if num % i == 0:
-                return i
-        # Unreachable because i=1 must hold.
-        return -1
-
-    outs = [outs] if isinstance(outs, _tvm.te.tensor.Tensor) else outs
-    sch = _tvm.te.create_schedule([x.op for x in outs])
-
-    _tvm.te.schedule.AutoInlineInjective(sch)
-    for out in outs:
-        if not _topi.utils.is_empty_shape(out.shape):
-            fused = sch[out].fuse(*sch[out].op.axis)
-
-            # Vectorize on fp16 data type to enable half2 for better memory bandwidth utilization.
-            vector_width = 2 if out.dtype == "float16" else 1
-
-            out_len = _topi.utils.prod(out.shape)
-
-            try:
-                const_size = _topi.utils.get_const_int(out_len)
-
-                # Adjust block and thread to make sure they are dividable so that vectorize can be
-                # correctly applied.
-                if vector_width > 1 and const_size % vector_width == 0:
-                    remain_total_size = const_size // vector_width
-                    cand_sizes = []
-                    for max_size in [num_thread, max_block]:
-                        cand_sizes.append(
-                            max_size
-                            if remain_total_size % max_size == 0
-                            else find_nearest_small_factor(remain_total_size, max_size)
-                        )
-                        remain_total_size //= cand_sizes[-1]
-
-                    # If the product of candidate dividable (block * thread) is too small,
-                    # then the performance may be worse even half2 is enabled. Note that 0.7
-                    # is just a heuristic ratio and may not be optimal for all workloads.
-                    if np.prod(cand_sizes) / (max_block * num_thread) >= 0.7:
-                        num_thread, max_block = cand_sizes
-
-                need_block_split = const_size > max_block * num_thread * vector_width
-            except ValueError:
-                need_block_split = False
-                const_size = 0
-
-            if vector_width > 1:
-                fused, v = sch[out].split(fused, vector_width)
-                sch[out].vectorize(v)
-
-            if need_block_split:
-                xo, xi = sch[out].split(fused, factor=num_thread * max_block)
-                bx, tx = sch[out].split(xi, factor=num_thread)
-                sch[out].reorder(bx, tx, xo)
-                sch[out].bind(bx, _tvm.te.thread_axis("blockIdx.x"))
-                sch[out].bind(tx, _tvm.te.thread_axis("threadIdx.x"))
-            else:
-                if const_size != 0 and const_size < num_thread:
-                    bx, tx = sch[out].split(fused, factor=const_size)
-                else:
-                    bx, tx = sch[out].split(fused, factor=num_thread)
-                sch[out].bind(tx, _tvm.te.thread_axis("threadIdx.x"))
-                sch[out].bind(bx, _tvm.te.thread_axis("blockIdx.x"))
-    return sch
-
-
 @register_compute("raf.op.tvm.sum")
 def sum_compute(attrs, inputs, output_type):  # pylint: disable=no-member
     x = inputs[0]
@@ -314,6 +67,255 @@ def schedule_sum(attrs, outs, target):
         return _topi.generic.schedule_injective(outs)
 
 
+def _schedule_cuda_sum_long_reduce(op, sch, **kwargs):
+    """The helper function for scheduling sum with long reduction length for CUDA.
+    In this case, we want to parallelize the reduction to keep the GPU busy. This is modified
+    from TOPI reduce schedule for CUDA.
+
+    Parameters
+    ----------
+    op: tvm.Operation
+        The operator being scheduled.
+
+    sch: tvm.schedule.Schedule
+        The working schedule.
+
+    **kwargs: Dict[str, List[Any]]
+        Tunable parameters. If not presents, the default values will be used.
+
+    Returns
+    -------
+    sch: Schedule
+        The computation schedule for the op.
+    """
+    # pylint: disable=invalid-name
+    # Setup the tunable parameter value.
+    num_thread = kwargs.get("num_thread", 32)
+    thread_x = _tvm.te.thread_axis((0, num_thread), "threadIdx.x")
+
+    data_out = op.output(0)
+
+    # Fuse and rfactor the reduce axis
+    fused_reduce = sch[data_out].fuse(
+        *[sch[data_out].op.reduce_axis[i] for i in range(len(sch[data_out].op.reduce_axis))]
+    )
+    _, ki = sch[data_out].split(fused_reduce, factor=num_thread)
+    data_out_rf = sch.rfactor(data_out, ki)
+    tx = sch[data_out].op.reduce_axis[0]
+    sch[data_out].bind(tx, thread_x)
+    sch[data_out_rf].compute_at(sch[data_out], tx)
+
+    if len(sch[data_out].op.axis) > 0:
+        # There are one or more axes to not reduced. Here we bind them to threads and blocks
+        # for parallelism.
+        block_x = _tvm.te.thread_axis("blockIdx.x")
+        thread_y = _tvm.te.thread_axis((0, num_thread), "threadIdx.y")
+
+        # Fuse and split the axis
+        fused_outer = sch[data_out].fuse(
+            *[sch[data_out].op.axis[i] for i in range(len(sch[data_out].op.axis))]
+        )
+        bx, outer_in = sch[data_out].split(fused_outer, factor=num_thread)
+
+        # Bind non-reduced axes to threads and blocks
+        sch[data_out].bind(outer_in, thread_y)
+        sch[data_out].bind(bx, block_x)
+        sch[data_out].set_store_predicate(
+            _tvm.tir.all(
+                thread_x.equal(0), block_x * num_thread + thread_y < reduce(mul, data_out.shape)
+            )
+        )
+    else:
+        # All axes are reduced.
+        sch[data_out].set_store_predicate(thread_x.equal(0))
+    return sch
+
+
+@profile_schedule(num_thread=[8, 16, 32, 64])
+def schedule_cuda_sum_long_reduce(outs, **kwargs):
+    """Schedule sum for CUDA. This schedule targets to the sum with long reduction length.
+    In this case, we want to parallelize the reduction to keep the GPU busy. This is modified
+    from TOPI reduce schedule for CUDA.
+
+    Parameters
+    ----------
+    outs: Array of Tensor
+        The computation graph description of reduce in the format of an array of tensors.
+
+    **kwargs: Dict[str, List[Any]]
+        Tunable parameters. If not presents, the default values will be used.
+
+    Returns
+    -------
+    sch: Schedule
+        The computation schedule for the op.
+    """
+    outs = [outs] if isinstance(outs, _tvm.te.tensor.Tensor) else outs
+    sch = _tvm.te.create_schedule([x.op for x in outs])
+    scheduled_ops = []
+
+    def _enable_auto_inline(sch):
+        def is_scheduled(stage):
+            # auto inline requires the attach type is AttachType.kGroupRoot
+            conds = [
+                len(stage.relations) == 0,
+                stage.attach_type == 1,
+                stage.all_iter_vars == stage.leaf_iter_vars,
+            ]
+            if not all(conds):
+                return True
+            return False
+
+        for stage in sch.stages:
+            if not stage.is_output and isinstance(stage.op, _tvm.te.ComputeOp):
+                if is_scheduled(stage) or len(stage.op.reduce_axis) != 0:
+                    return False
+        return True
+
+    enable_auto_inline = _enable_auto_inline(sch)
+
+    def traverse_before_reduce(tensor):
+        """Internal traverse function"""
+        operator = tensor.op
+        if isinstance(operator, _tvm.te.PlaceholderOp):
+            return
+        if _topi.tag.is_injective(operator.tag):
+            sch[operator].compute_inline()
+            for inp_tensor in operator.input_tensors:
+                if inp_tensor.op not in scheduled_ops:
+                    traverse_before_reduce(inp_tensor)
+        else:
+            raise RuntimeError("Unsupported operator: %s" % operator.tag)
+
+        scheduled_ops.append(operator)
+
+    def traverse_after_reduce(tensor):
+        """Internal traverse function"""
+        operator = tensor.op
+        if _topi.tag.is_broadcast(operator.tag):
+            if operator not in scheduled_ops:
+                _topi.schedule_injective_from_existing(  # pylint: disable=no-member
+                    sch, operator.output(0)
+                )
+            for inp_tensor in operator.input_tensors:
+                if inp_tensor.op not in scheduled_ops:
+                    if enable_auto_inline:
+                        traverse_before_reduce(inp_tensor)
+                    else:
+                        traverse_after_reduce(inp_tensor)
+        elif operator.tag == "comm_reduce":
+            if operator not in scheduled_ops:
+                _schedule_cuda_sum_long_reduce(operator, sch, **kwargs)
+            for inp_tensor in operator.input_tensors:
+                if inp_tensor.op not in scheduled_ops:
+                    traverse_before_reduce(inp_tensor)
+        elif isinstance(operator, _tvm.te.PlaceholderOp):
+            pass
+        else:
+            raise RuntimeError("Unsupported operator tag: %s" % operator.tag)
+
+        scheduled_ops.append(operator)
+
+    for out in outs:
+        traverse_after_reduce(out)
+
+    return sch
+
+
+@profile_schedule(num_thread=[16, 32, 64], max_block=[128, 256, 512])
+def schedule_cuda_short_reduce(outs, **kwargs):
+    """Schedule sum for CUDA. This schedule targets to the sum with short reduction length.
+    In this case, each thread is responsible for reduction. The parallelization is across
+    the output elements. This is modified from TOPI injective schedule for CUDA.
+
+    Parameters
+    ----------
+    outs: Array of Tensor
+        The computation graph description of injective in the format of an array of tensors.
+
+    **kwargs: Dict[str, List[Any]]
+        Tunable parameters. If not presents, the default values will be used.
+
+    Returns
+    -------
+    sch: Schedule
+        The computation schedule for the op.
+    """
+    # pylint: disable=invalid-name
+    # Tunable parameters.
+    num_thread = kwargs.get(
+        "num_thread", _tvm.target.Target.current(allow_none=False).max_num_threads
+    )
+    max_block = kwargs.get("max_block", 256)
+
+    def find_nearest_small_factor(num, target):
+        """Find the nearest factor of the given number that is smaller than the target."""
+        for i in range(target, 0, -1):
+            if num % i == 0:
+                return i
+        # Unreachable because i=1 must hold.
+        return -1
+
+    outs = [outs] if isinstance(outs, _tvm.te.tensor.Tensor) else outs
+    sch = _tvm.te.create_schedule([x.op for x in outs])
+
+    _tvm.te.schedule.AutoInlineInjective(sch)  # pylint: disable=no-member
+    for out in outs:
+        if not _topi.utils.is_empty_shape(out.shape):
+            fused = sch[out].fuse(*sch[out].op.axis)
+
+            # Vectorize on fp16 data type to enable half2 for better memory bandwidth utilization.
+            vector_width = 2 if out.dtype == "float16" else 1
+
+            out_len = _topi.utils.prod(out.shape)
+
+            try:
+                const_size = _topi.utils.get_const_int(out_len)
+
+                # Adjust block and thread to make sure they are dividable so that vectorize can be
+                # correctly applied.
+                if vector_width > 1 and const_size % vector_width == 0:
+                    remain_total_size = const_size // vector_width
+                    cand_sizes = [0, 0]
+                    for idx, max_size in enumerate([num_thread, max_block]):
+                        cand_sizes[idx] = (
+                            max_size
+                            if remain_total_size % max_size == 0
+                            else find_nearest_small_factor(remain_total_size, max_size)
+                        )
+                        remain_total_size //= cand_sizes[-1]
+
+                    # If the product of candidate dividable (block * thread) is too small,
+                    # then the performance may be worse even half2 is enabled. Note that 0.7
+                    # is just a heuristic ratio and may not be optimal for all workloads.
+                    if np.prod(cand_sizes) / (max_block * num_thread) >= 0.7:
+                        num_thread, max_block = cand_sizes
+
+                need_block_split = const_size > max_block * num_thread * vector_width
+            except ValueError:
+                need_block_split = False
+                const_size = 0
+
+            if vector_width > 1:
+                fused, vec = sch[out].split(fused, vector_width)
+                sch[out].vectorize(vec)
+
+            if need_block_split:
+                xo, xi = sch[out].split(fused, factor=num_thread * max_block)
+                bx, tx = sch[out].split(xi, factor=num_thread)
+                sch[out].reorder(bx, tx, xo)
+                sch[out].bind(bx, _tvm.te.thread_axis("blockIdx.x"))
+                sch[out].bind(tx, _tvm.te.thread_axis("threadIdx.x"))
+            else:
+                if const_size != 0 and const_size < num_thread:
+                    bx, tx = sch[out].split(fused, factor=const_size)
+                else:
+                    bx, tx = sch[out].split(fused, factor=num_thread)
+                sch[out].bind(tx, _tvm.te.thread_axis("threadIdx.x"))
+                sch[out].bind(bx, _tvm.te.thread_axis("blockIdx.x"))
+    return sch
+
+
 @schedule_sum.register(["cuda", "gpu"])
 def schedule_sum_cuda(attrs, outs, target):
     # pylint: disable=unused-argument
@@ -329,11 +331,8 @@ def schedule_sum_cuda(attrs, outs, target):
         num_out_elements = get_num_elements(out.op.axis)
         num_reduce_elements = get_num_elements(out.op.reduce_axis)
 
-        # We want to saturate the GPU cores by parallelization. There are 2 scenarios
-        # 1) Reduce dimension is small - In this case, each thread is responsible for reduction.
-        # The parallelization is across the output elements.
-        # 2) Reduce dimension is large - We want to parallelize the reduction to keep the GPU busy.
-        # Here we fall back to TVM schedule.
+        # We attempt to saturate the GPU cores by parallelization, so we dispatch
+        # the sum workloads to two schedules based on their reduction length.
         if num_out_elements > num_reduce_elements:
             return schedule_cuda_short_reduce(outs)
 

--- a/python/raf/_tvm_op/reduce.py
+++ b/python/raf/_tvm_op/reduce.py
@@ -283,7 +283,7 @@ def schedule_cuda_short_reduce(outs, **kwargs):
                             if remain_total_size % max_size == 0
                             else find_nearest_small_factor(remain_total_size, max_size)
                         )
-                        remain_total_size //= cand_sizes[-1]
+                        remain_total_size //= cand_sizes[idx]
 
                     # If the product of candidate dividable (block * thread) is too small,
                     # then the performance may be worse even half2 is enabled. Note that 0.7

--- a/python/raf/_tvm_op/reduce.py
+++ b/python/raf/_tvm_op/reduce.py
@@ -177,7 +177,7 @@ def schedule_cuda_sum_long_reduce(outs, **kwargs):
     return sch
 
 
-@profile_schedule(num_thread=[16, 32, 64], max_block=[64, 128, 256, 512])
+@profile_schedule(num_thread=[16, 32, 64], max_block=[128, 256, 512])
 def schedule_cuda_short_reduce(outs, **kwargs):
     """Schedule sum as an injective op.
 
@@ -249,7 +249,6 @@ def schedule_cuda_short_reduce(outs, **kwargs):
                 fused, v = sch[out].split(fused, vector_width)
                 sch[out].vectorize(v)
 
-            print(need_block_split, num_thread, max_block)
             if need_block_split:
                 xo, xi = sch[out].split(fused, factor=num_thread * max_block)
                 bx, tx = sch[out].split(xi, factor=num_thread)
@@ -257,7 +256,6 @@ def schedule_cuda_short_reduce(outs, **kwargs):
                 sch[out].bind(bx, _tvm.te.thread_axis("blockIdx.x"))
                 sch[out].bind(tx, _tvm.te.thread_axis("threadIdx.x"))
             else:
-                print("const", const_size)
                 if const_size != 0 and const_size < num_thread:
                     bx, tx = sch[out].split(fused, factor=const_size)
                 else:

--- a/python/raf/_tvm_op/utils.py
+++ b/python/raf/_tvm_op/utils.py
@@ -5,6 +5,8 @@
 # pylint: disable=protected-access
 import os
 
+import numpy as np
+
 import tvm
 
 
@@ -45,3 +47,88 @@ def load_module(path):
     if not os.path.exists(path):
         raise RuntimeError("Module file does not exist {}".format(path))
     return tvm.runtime.module.load_module(path)
+
+
+def profile_schedule(**params):
+    """A lightwight tuner for TOPI schedules. It is similar to AutoTVM but very lightweight.
+    It can be used as follows:
+
+    ```python
+    @profile_schedule(num_thread=[8, 16, 32, 64])
+    def _schedule_cuda(outs, **kwargs):
+        num_thread = kwargs.get("num_thread", 32) # Get tuned value or default.
+        ...
+        return sch
+
+    @schedule_sum.register(["cuda", "gpu"])
+    def schedule_cuda(attrs, outs, target):
+        with target:
+            return _schedule_cuda(outs)
+    ```
+
+    The above code snippet profiles 4 schedules with different num_thread and returns
+    the best one. Since we directly use tvm.build to compile and evaluate the schedule
+    without heavy RFC mechanism and reuse the random data inputs, this is lightwieght
+    compared to AutoTVM and auto-schedule and can be used for JIT compilation. However,
+    develoeprs should control the tuning space to avoid long JIT time. It is recommended
+    to have <10 tuning space when using this function.
+    """
+
+    def _wrapper(sch_func):
+        def _profile(outs):
+            outs = [outs] if isinstance(outs, tvm.te.tensor.Tensor) else outs
+
+            # Collect arguments.
+            args_set = set()
+
+            def collect_args(tensor):
+                operator = tensor.op
+                if isinstance(operator, tvm.te.PlaceholderOp):
+                    args_set.add(tensor)
+                else:
+                    for inp_tensor in operator.input_tensors:
+                        collect_args(inp_tensor)
+
+            for out in outs:
+                collect_args(out)
+
+            # Generate random input data for profiling.
+            tvm_target = tvm.target.Target.current()
+            tvm_device = tvm.device(str(tvm_target), 0)  # FIXME
+            args = list(args_set)
+            args_data = []
+            for arg in args:
+                shape = [s.value for s in arg.shape]
+                args_data.append(
+                    tvm.nd.array(np.random.uniform(size=shape).astype(arg.dtype), tvm_device)
+                )
+
+            # Profiling
+            def profile_param(param_list, param_dict):
+                if not param_list:
+                    sch = sch_func(outs, **param_dict)
+                    try:
+                        func = tvm.build(sch, args, tvm_target)
+                        evaluator = func.time_evaluator(func.entry_name, tvm_device, number=5)
+                        latency = evaluator(*args_data).median
+                    except Exception:  # pylint: disable=broad-except
+                        latency = float("inf")
+                    return sch, latency
+                else:
+                    best_sch_n_latency = None
+                    key, vals = param_list[0]
+                    for val in vals:
+                        param_dict[key] = val
+                        sch, latency = profile_param(param_list[1:], param_dict)
+                        if best_sch_n_latency is None or latency < best_sch_n_latency[1]:
+                            best_sch_n_latency = (sch, latency)
+                    assert best_sch_n_latency is not None
+                    return best_sch_n_latency
+
+            sch, _ = profile_param(list(params.items()), {})
+            del args_data
+            return sch
+
+        return _profile
+
+    return _wrapper

--- a/python/raf/_tvm_op/utils.py
+++ b/python/raf/_tvm_op/utils.py
@@ -9,6 +9,8 @@ import numpy as np
 
 import tvm
 
+from raf import distributed as dist
+
 
 @tvm._ffi.register_func("raf._tvm_op.utils.export_library")
 def export_library(mod, path):
@@ -74,9 +76,13 @@ def profile_schedule(**params):
     to have <10 tuning space when using this function.
     """
     enable = os.environ.get("RAF_JIT_TUNE", False)
+    comm = dist.get_communicator()
+    local_rank = comm.local_rank
 
     def _wrapper(sch_func):
         def _profile(outs):
+            # If not enabled, do not pass any tunable parameters so that the schedule
+            # function will use the built-in default values.
             if not enable:
                 return sch_func(outs)
 
@@ -98,7 +104,7 @@ def profile_schedule(**params):
 
             # Generate random input data for profiling.
             tvm_target = tvm.target.Target.current()
-            tvm_device = tvm.device(str(tvm_target), 0)  # FIXME
+            tvm_device = tvm.device(str(tvm_target), local_rank)
             args = list(args_set)
             args_data = []
             for arg in args:
@@ -113,6 +119,7 @@ def profile_schedule(**params):
                     sch = sch_func(outs, **param_dict)
                     try:
                         func = tvm.build(sch, args, tvm_target)
+                        # Run 5 times and take the median value to avoid outliers.
                         evaluator = func.time_evaluator(func.entry_name, tvm_device, number=5)
                         latency = evaluator(*args_data).median
                     except Exception:  # pylint: disable=broad-except

--- a/python/raf/_tvm_op/utils.py
+++ b/python/raf/_tvm_op/utils.py
@@ -73,9 +73,13 @@ def profile_schedule(**params):
     develoeprs should control the tuning space to avoid long JIT time. It is recommended
     to have <10 tuning space when using this function.
     """
+    enable = os.environ.get("RAF_JIT_TUNE", False)
 
     def _wrapper(sch_func):
         def _profile(outs):
+            if not enable:
+                return sch_func(outs)
+
             outs = [outs] if isinstance(outs, tvm.te.tensor.Tensor) else outs
 
             # Collect arguments.


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
Based on the recent observation by @zhen-jia, `sum` sometimes can achieve better performance (up to 10x on p4d) by auto-scheduler. Since the tuning space for `sum` should be very small, I investigated the well tuned schedule and concluded that the only difference is the choose of thread and block sizes. However, analytically choosing them in TOPI schedules seems challenging, and launching auto-scheduler is too time-consuming for JIT.

Accordingly, this PR proposes a lightweight TOPI schedule tuner. The concept is similar to MetaSchedule presented in TVM, but more straightforward/simpler. We could, of course, get rid of this mechanism after switching to MetaSchedule in the future.

Specifically, this mechanism works as follows:

```python
@profile_schedule(num_thread=[16, 32, 64], max_block=[128, 256, 512])
def schedule_cuda_short_reduce(outs, **kwargs):
    num_thread = kwargs.get(
        "num_thread", _tvm.target.Target.current(allow_none=False).max_num_threads
    )
    max_block = kwargs.get("max_block", 256)
   ...
  return sch
```

1. The TOPI schedule accepts `**kwargs`, which includes tunable parameters.
2. The TOPI schedule gets the parameter values from `kwargs`, and assigns default values when missing.
3. A new introduced decorator `profile_schedule` for TOPI schedules lets you specify tunable parameters and their possible values.
4. The tuning is now disabled by default, and could be enabled by an environment variable `RAF_JIT_TUNE=1`. **Please refer to the following evaluation results and share your thoughts about whether we should make it enable by default.**

What actually happens underlying is that we wrap the TOPI schedule function, exhaustively generate/evaluate schedules with all parameter combinations, and return the best one. The evaluation simply uses `tvm.build` and `func.time_evaluator` to measure the latency. In the above example, it will profile 3x3=9 schedules and select the best one.

With this mechanism, this PR modified the `sum` schedule and introduces tunable parameters. The tuning space is 4 or 9 depending on the reduction length. Here are the evaluation results based on the sum workloads extracted from custom 1.5B model, BERT, and GPT-2. We evaluated both FP16 and FP32 workloads (note that AMP results are similar to FP16 so we don't put them here) on p3.2xl. There are two insights from the results:

1. With tuning, we achieve 1x-9.9x speedup. The workloads without speedup are the ones that reduce the outermost dimension. AFAIK, we cannot achieve better speedup with TE schedules for now.
2. Although the JIT overhead is increased, it could still finish lower-tune-compile within 10 seconds. This should be acceptable, because CuDNN and CUTLASS also take similar time to benchmark algorithms/tile sizes.

Source | Input, \| Output | Origin Latency (ms) | Origin JIT Time (s) | Tuned Latency (ms) | Tuned  JIT Time (s) | Speedup
-- | -- | -- | -- | -- | -- | --
Custom 1.5B | T<8x512x30000xf16>,\|T<30000xf16>: | 1.99 | 0.52 | 0.34 | 7.35 | 5.85
Custom 1.5B | T<8x512x1536xf16>,\|T<1536xf16>: | 0.13 | 0.58 | 0.04 | 2.79 | 3.25
BERT | T<4096x30522xf16>,\|T<4096x1xf16>: | 0.48 | 0.52 | 0.48 | 4.78 | 1.00
BERT | T<4096x30522xf16>,\|T<30522xf16>: | 1.98 | 0.51 | 1.67 | 7.59 | 1.19
BERT | T<8x512x30522xf16>,\|T<30522xf16>: | 1.99 | 0.52 | 1.68 | 7.61 | 1.18
BERT | T<8x512x30522xf16>,\|T<8x512xf16>: | 0.48 | 0.52 | 0.48 | 4.78 | 1.00
BERT | T<8x512x768xf16>,\|T<768xf16>: | 0.13 | 0.59 | 0.03 | 2.72 | 4.33
BERT | T<8x512x768xf16>,\|T<1x512x768xf16>: | 0.03 | 0.51 | 0.02 | 5.05 | 1.50
BERT | T<8x512x3072xf16>,\|T<3072xf16>: | 0.24 | 0.59 | 0.07 | 2.89 | 3.43
GPT-2 | T<8192x50257xf16>,\|T<8192x1xf16>: | 1.64 | 0.53 | 1.61 | 9.94 | 1.02
GPT-2 | T<8192x768xf16>,\|T<768xf16>: | 0.22 | 0.54 | 0.06 | 2.77 | 3.67
GPT-2 | T<8192x3072xf16>,\|T<3072xf16>: | 0.46 | 0.55 | 0.18 | 3.16 | 2.56
GPT-2 | T<8192x2304xf16>,\|T<2304xf16>: | 0.24 | 0.55 | 0.10 | 3.02 | 2.40
GPT-2 | T<8192x768xf16>,\|T<1x768xf16>: | 0.23 | 0.55 | 0.06 | 2.81 | 3.83
Custom 1.5B | T<8x512x30000xf32>,\|T<30000xf32>: | 2.51 | 0.45 | 0.60 | 6.34 | 4.18
Custom 1.5B | T<8x512x1536xf32>,\|T<1536xf32>: | 0.13 | 0.46 | 0.05 | 2.36 | 2.60
BERT | T<4096x30522xf32>,\|T<4096x1xf32>: | 0.64 | 0.45 | 0.64 | 4.06 | 1.00
BERT | T<4096x30522xf32>,\|T<30522xf32>: | 0.67 | 0.44 | 0.68 | 6.35 | 0.99
BERT | T<8x512x30522xf32>,\|T<30522xf32>: | 0.65 | 0.45 | 0.69 | 6.39 | 0.94
BERT | T<8x512x30522xf32>,\|T<8x512xf32>: | 0.64 | 0.45 | 0.64 | 4.04 | 1.00
BERT | T<8x512x768xf32>,\|T<768xf32>: | 0.12 | 0.46 | 0.04 | 2.31 | 3.00
BERT | T<8x512x768xf32>,\|T<1x512x768xf32>: | 0.04 | 0.45 | 0.03 | 4.60 | 1.33
BERT | T<8x512x3072xf32>,\|T<3072xf32>: | 0.23 | 0.47 | 0.08 | 2.47 | 2.88
GPT-2 | T<8192x50257xf32>,\|T<8192x1xf32>: | 2.10 | 0.45 | 2.07 | 8.22 | 1.01
GPT-2 | T<8192x768xf32>,\|T<768xf32>: | 0.21 | 0.46 | 0.06 | 2.33 | 3.50
GPT-2 | T<8192x3072xf32>,\|T<3072xf32>: | 0.51 | 0.46 | 0.35 | 2.62 | 1.46
GPT-2 | T<8192x2304xf32>,\|T<2304xf32>: | 0.27 | 0.46 | 0.12 | 2.53 | 2.25
GPT-2 | T<8192x768xf32>,\|T<1x768xf32>: | 0.23 | 0.46 | 0.06 | 2.34 | 3.83

## Checklist ##

- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @awslabs/raf-reviewer @yzhliu @zhen-jia @hzfan @zhouyuan1119 @whbldhwj @junrushao1994 
