### PR TITLE
[Op][TVM] Miner improvements for TOPI tuner

### DIFF
--- a/python/raf/_tvm_op/utils.py
+++ b/python/raf/_tvm_op/utils.py
@@ -87,7 +87,7 @@ def profile_schedule(**params):
     if "validator" in params:
         validator = params["validator"]
         del params["validator"]
-    enable = os.environ.get("RAF_JIT_TUNE", True)
+    enable = bool(int(os.environ.get("RAF_JIT_TUNE", 1)))
     comm = dist.get_communicator()
     local_rank = comm.local_rank
 

--- a/python/raf/_tvm_op/utils.py
+++ b/python/raf/_tvm_op/utils.py
@@ -149,7 +149,6 @@ def profile_schedule(**params):
                         sch, latency = profile_param(param_list[1:], param_dict)
                         if best_sch_n_latency[0] is None or latency < best_sch_n_latency[1]:
                             best_sch_n_latency = (sch, latency)
-                    assert best_sch_n_latency is not None
                     return best_sch_n_latency
 
                 # All parameter values are determined and in param_dict, evaluate the schedule.

--- a/python/raf/_tvm_op/utils.py
+++ b/python/raf/_tvm_op/utils.py
@@ -51,6 +51,11 @@ def load_module(path):
     return tvm.runtime.module.load_module(path)
 
 
+def get_cuda_max_thread():
+    """A helper function to obtain the maximum number of threads per block."""
+    return tvm.target.Target("cuda").max_num_threads
+
+
 def profile_schedule(**params):
     """A lightwight tuner for TOPI schedules. It is similar to AutoTVM but very lightweight.
     It can be used as follows:

--- a/python/raf/_tvm_op/utils.py
+++ b/python/raf/_tvm_op/utils.py
@@ -116,7 +116,7 @@ def profile_schedule(**params):
                 collect_args(out)
 
             # Generate random input data for profiling.
-            tvm_target = tvm.target.Target.current()
+            tvm_target = tvm.target.Target.current(allow_none=False)
             tvm_device = tvm.device(str(tvm_target), local_rank)
             args = list(args_set)
             args_data = []


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##

1. Include `max_num_thread` and remove 16 in the tuning space. This config is useful when scheduling all reduce workloads.
2. Isolate performance evaluation to another thread to avoid environment inconsistency caused by compilation failure.

## Checklist ##

- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @awslabs/raf-reviewer
