### PR TITLE
[Setup] Fix setup.py for dist build and add test

### DIFF
--- a/ci/task_build.sh
+++ b/ci/task_build.sh
@@ -15,16 +15,16 @@ git checkout --recurse-submodules .
 
 # build
 mkdir -p $BUILD_DIR
-pushd
+pushd .
 cd $BUILD_DIR && cmake .. && make $MAKE_FLAGS && make raf-cpptest $MAKE_FLAGS
 popd
 
 # test build wheels
 export TVM_LIBRARY_PATH=${PWD}/build/lib
-pushd
+pushd .
 cd 3rdparty/tvm/python && python3 setup.py bdist_wheel -d ../build/pip/public/tvm_latest
 popd
-pushd
+pushd .
 cd python && python3 setup.py bdist_wheel -d ../build/pip/public/raf
 popd
 

--- a/ci/task_build.sh
+++ b/ci/task_build.sh
@@ -23,8 +23,10 @@ popd
 export TVM_LIBRARY_PATH=${PWD}/build/lib
 pushd .
 cd 3rdparty/tvm/python && python3 setup.py bdist_wheel -d ../build/pip/public/tvm_latest
+python3 -m pip install ../build/pip/public/tvm_latest/*.whl --upgrade --force-reinstall --no-deps
 popd
 pushd .
 cd python && python3 setup.py bdist_wheel -d ../build/pip/public/raf
+python3 -m pip install ../build/pip/public/raf/*.whl --upgrade --force-reinstall --no-deps
 popd
 

--- a/ci/task_build.sh
+++ b/ci/task_build.sh
@@ -16,3 +16,9 @@ git checkout --recurse-submodules .
 # build
 mkdir -p $BUILD_DIR
 cd $BUILD_DIR && cmake .. && make $MAKE_FLAGS && make raf-cpptest $MAKE_FLAGS && cd ..
+
+# test build wheels
+export TVM_LIBRARY_PATH=${PWD}/build/lib
+cd 3rdparty/tvm/python && python3 setup.py bdist_wheel -d ../build/pip/public/tvm_latest
+cd python && python3 setup.py bdist_wheel -d ../build/pip/public/raf
+

--- a/ci/task_build.sh
+++ b/ci/task_build.sh
@@ -22,11 +22,13 @@ popd
 # test build wheels
 export TVM_LIBRARY_PATH=${PWD}/build/lib
 pushd .
-cd 3rdparty/tvm/python && python3 setup.py bdist_wheel -d ../build/pip/public/tvm_latest
+cd 3rdparty/tvm/python
+python3 setup.py bdist_wheel -d ../build/pip/public/tvm_latest
 python3 -m pip install ../build/pip/public/tvm_latest/*.whl --upgrade --force-reinstall --no-deps
 popd
 pushd .
-cd python && python3 setup.py bdist_wheel -d ../build/pip/public/raf
+cd python
+TVM_FFI=auto python3 setup.py bdist_wheel -d ../build/pip/public/raf
 python3 -m pip install ../build/pip/public/raf/*.whl --upgrade --force-reinstall --no-deps
 popd
 

--- a/ci/task_build.sh
+++ b/ci/task_build.sh
@@ -15,10 +15,16 @@ git checkout --recurse-submodules .
 
 # build
 mkdir -p $BUILD_DIR
-cd $BUILD_DIR && cmake .. && make $MAKE_FLAGS && make raf-cpptest $MAKE_FLAGS && cd ..
+pushd
+cd $BUILD_DIR && cmake .. && make $MAKE_FLAGS && make raf-cpptest $MAKE_FLAGS
+popd
 
 # test build wheels
 export TVM_LIBRARY_PATH=${PWD}/build/lib
+pushd
 cd 3rdparty/tvm/python && python3 setup.py bdist_wheel -d ../build/pip/public/tvm_latest
+popd
+pushd
 cd python && python3 setup.py bdist_wheel -d ../build/pip/public/raf
+popd
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,7 +6,6 @@ import os
 import shutil
 import subprocess
 import sys
-import sysconfig
 
 from setuptools import find_packages
 from setuptools.dist import Distribution

--- a/python/setup.py
+++ b/python/setup.py
@@ -29,7 +29,6 @@ def get_env_flag(name, default=""):
     return os.getenv(name, default).upper() in ["ON", "1", "YES", "TRUE", "Y"]
 
 
-# FIXME: get_lib_path() does not work as line 36: "exec(compile(ss, libinfo_py, "exec"), libinfo, libinfo)" errors
 def get_lib_path():
     """Get library path, name and version"""
     # We can not import `libinfo.py` in setup.py directly since __init__.py
@@ -66,8 +65,7 @@ def get_build_version():
     return version
 
 
-# FIXME: commented out LIB_LIST because it relies on get_lib_path()
-# LIB_LIST = get_lib_path()
+LIB_LIST = get_lib_path()
 
 # FIXME: commented out _version_ because subprocess.CalledProcessError: Command '['git', 'rev-parse', '--short', 'HEAD']' returned non-zero exit status 128.
 # __version__ = get_build_version()
@@ -162,14 +160,11 @@ if wheel_include_libs:
             fo.write("include raf/%s\n" % libname)
     setup_kwargs = {"include_package_data": True}
 
-# FIXME: this if statement does not work as it relies on get_lib_path()
-"""
 if include_libs:
     curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
     for i, path in enumerate(LIB_LIST):
         LIB_LIST[i] = os.path.relpath(path, curr_path)
     setup_kwargs = {"include_package_data": True, "data_files": [("raf", LIB_LIST)]}
-"""
 
 # Local change: Write out version to file and include in package
 os.makedirs(os.path.join(SCRIPT_DIR, "../build/private/raf/version"), exist_ok=True)

--- a/scripts/wheel/build_wheel_manylinux.sh
+++ b/scripts/wheel/build_wheel_manylinux.sh
@@ -45,4 +45,5 @@ python3 -c "import raf"
 
 # Generate source distribution
 cd ../..
-python3 ./setup.py sdist
+python3 ./setup.py bdist_wheel -d ../build/pipe/public/raf
+

--- a/scripts/wheel/build_wheel_manylinux.sh
+++ b/scripts/wheel/build_wheel_manylinux.sh
@@ -13,6 +13,7 @@ bash ./scripts/src_codegen/run_all.sh
 
 # TODO: Make this part of creating CMake configurable. It should take arguments from the command line to determine the configuration.  
 # Configuration file for CMake
+pushd .
 cd $RAF_HOME/build
 cp ../cmake/config.cmake .
 
@@ -44,6 +45,8 @@ export TVM_LIBRARY_PATH=$RAF_HOME/build/lib
 python3 -c "import raf"
 
 # Generate source distribution
-cd ../..
+popd
+pushd .
+cd python
 python3 ./setup.py bdist_wheel -d ../build/pipe/public/raf
 


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
The last PR changed `setup.py` doesn't work for wheel build and breaks the daily benchmark (https://github.com/meta-project/models/runs/6893167470?check_suite_focus=true) due to undefined `LIB_LIST`. This PR changes the following:

- Since we are going to use a bash script to build RAF and only use setup.py for packaging, `get_lib_path()` should be working, so I uncommented `LIB_LIST`.
- Changed the bash script to build wheel instead of source. Ref: https://medium.com/ochrona/understanding-python-package-distribution-types-25d53308a9a
- Try to build wheels in CI to cover any future changes.

## Checklist ##

- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @awslabs/raf-reviewer @sqsharma 
