### PR TITLE
[Op] Use y*y instead of 1/x^2 to calculate reciprocal gradients

### DIFF
--- a/src/op/grad/nn.cc
+++ b/src/op/grad/nn.cc
@@ -459,10 +459,8 @@ Array<Expr> ReciprocalGrad(const Expr& orig_call, const Array<Expr> orig_args, c
   const CallNode* call = orig_call.as<CallNode>();
   CHECK_GE(call->args.size(), 1);
   const Expr& x = call->args[0];
-  Call one = Call(op_ones, {x});
-  Call x_pow_2 = Call(op_multiply, {x, x});
-  Call one_divide_x_pow_2 = Call(op_div, {one, x_pow_2});
-  Call dx = Call(op_negative, {one_divide_x_pow_2});
+  Call y_multiply_y = Call(op_multiply, {y, y});
+  Call dx = Call(op_negative, {y_multiply_y});
   return {Call(op_multiply, {dy, dx})};
 }
 


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
Removed the unit test for reciprocal op with gradient on fp16.
Currently, reciprocal op will only run backward pass in fp32.

## Checklist ##

- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

cc @awslabs/raf-reviewer
