### PR TITLE
[Build] Exclude cuda etc. source files from RAF_CXX_SOURCE_FILES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,26 +90,19 @@ set_property(
 )
 
 file(GLOB_RECURSE RAF_CXX_SOURCE_FILES
-  ${CMAKE_CURRENT_LIST_DIR}/src/analysis/*.cc
-  ${CMAKE_CURRENT_LIST_DIR}/src/common/*.cc
-  ${CMAKE_CURRENT_LIST_DIR}/src/device_api/cpu/*.cc
-  ${CMAKE_CURRENT_LIST_DIR}/src/memory_pool/*.cc
-  ${CMAKE_CURRENT_LIST_DIR}/src/op/schema/*.cc
-  ${CMAKE_CURRENT_LIST_DIR}/src/op/declare/*.cc
-  ${CMAKE_CURRENT_LIST_DIR}/src/op/regs/*.cc
-  ${CMAKE_CURRENT_LIST_DIR}/src/op/grad/*.cc
-  ${CMAKE_CURRENT_LIST_DIR}/src/op/dialect/tvm/*.cc
-  ${CMAKE_CURRENT_LIST_DIR}/src/op/base_ops.cc
-  ${CMAKE_CURRENT_LIST_DIR}/src/op/from_relay/*.cc
-  ${CMAKE_CURRENT_LIST_DIR}/src/op/ty/*.cc
-  ${CMAKE_CURRENT_LIST_DIR}/src/pass/*.cc
-  ${CMAKE_CURRENT_LIST_DIR}/src/impl/*.cc
-  ${CMAKE_CURRENT_LIST_DIR}/src/profiler/memory_profiler.cc
-  ${CMAKE_CURRENT_LIST_DIR}/src/profiler/op_profiler.cc
-  ${CMAKE_CURRENT_LIST_DIR}/src/profiler/scope_timer.cc
-  ${CMAKE_CURRENT_LIST_DIR}/src/profiler/base/*.cc
-  ${CMAKE_CURRENT_LIST_DIR}/src/distributed/common/*.cc
+  ${CMAKE_CURRENT_LIST_DIR}/src/*/*.cc
 )
+file(GLOB_RECURSE RAF_EXCLUDE_CXX_SOURCE_FILES
+  ${CMAKE_CURRENT_LIST_DIR}/src/device_api/cuda/*.cc
+  ${CMAKE_CURRENT_LIST_DIR}/src/distributed/cuda/*.cc
+  ${CMAKE_CURRENT_LIST_DIR}/src/op/dialect/cublas/*.cc
+  ${CMAKE_CURRENT_LIST_DIR}/src/op/dialect/cuda/*.cc
+  ${CMAKE_CURRENT_LIST_DIR}/src/op/dialect/cudnn/*.cc
+  ${CMAKE_CURRENT_LIST_DIR}/src/op/dialect/cutlass/*.cc
+  ${CMAKE_CURRENT_LIST_DIR}/src/op/dialect/nccl/*.cc
+  ${CMAKE_CURRENT_LIST_DIR}/src/profiler/cuda/*.cc
+)
+list(REMOVE_ITEM RAF_CXX_SOURCE_FILES ${RAF_EXCLUDE_CXX_SOURCE_FILES})
 
 if (${RAF_USE_CUDA} STREQUAL "OFF")
   set(RAF_CUDA_SOURCE_FILES "")


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
Including all .cc and then exclude cuda etc. source files from RAF_CXX_SOURCE_FILES.
Just make it easier for internal repository to add extra source file directory (e.g., src/amazon)

## Checklist ##

- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

cc @comaniac @awslabs/raf-reviewer
