### PR TITLE
[Util] Use custom tensor set

### DIFF
--- a/python/raf/_tvm_op/utils.py
+++ b/python/raf/_tvm_op/utils.py
@@ -100,11 +100,13 @@ def profile_schedule(**params):
                 self.tensor_list = []
 
             def add(self, tensor):
+                """Add a tensor if it is not in the list."""
                 if any([tensor.same_as(t) for t in self.tensor_list]):
                     return
                 self.tensor_list.append(tensor)
 
             def to_list(self):
+                """Get the list of tensors."""
                 return self.tensor_list
 
         def _profile(outs, **kwargs):


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##

Somehow (I don't know the reason...) when pushing a `te.Tensor` to a Python set, `__eq__` will be invoked and may trigger the following error if the tensor is rank-0.

```
raf/src/op/dialect/tvm/tvm_fusion.cc:297: Failed to build a fused op fused_multiply_sqrt_cast_greater_add_divide_where_multiply_add_divide_multiply_m_16765600757613373181_: ValueError: Equal == comparison among rank-0 tensor is ambiguous, use Tensor.equal for content expression equvalence, use Tensor.same_as for exact reference comparison
```

This PR uses a custom set that explicitly leverages `same_as` to deduplicate tensors.

## Checklist ##

- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

cc @awslabs/raf-reviewer
