### PR TITLE
[Op] support 2-dim nll_loss label

### DIFF
--- a/python/raf/_tvm_op/loss.py
+++ b/python/raf/_tvm_op/loss.py
@@ -82,13 +82,20 @@ _reg.register_broadcast_schedule("raf.op.tvm.smooth_l1_loss_dtrue")
 @register_compute("raf.op.tvm.nll_loss")
 def nll_loss_compute(attrs, inputs, output_type):  # pylint: disable=unused-argument
     true, pred = inputs
-    n, _ = pred.shape
+    n, c = pred.shape
 
-    def fcompute(i):  # pylint: disable=unused-argument
-        return -pred[i, true[i]] / n
+    if true.ndim == 1:  # one-host label encoding
+        def fcompute_one_hot(i):  # pylint: disable=unused-argument
+            return -pred[i, true[i]] / n
+        loss = _tvm.te.compute((n, ), fcompute_one_hot)
+        loss = _topi.sum(loss, axis=[0], keepdims=True)
+    else:  # sparse label encoding
+        def fcompute_sparse(x):  # pylint: disable=unused-argument
+            redn = _tvm.te.reduce_axis((0, n), name='rn')
+            redc = _tvm.te.reduce_axis((0, c), name='rc')
+            return _tvm.te.sum(-pred[redn, redc] * true[redn, redc] / n, axis=[redc, redn])
+        loss = _tvm.te.compute((1, ), fcompute_sparse)
 
-    loss = _tvm.te.compute((n,), fcompute)
-    loss = _topi.sum(loss, axis=[0], keepdims=True)
     return [loss]
 
 
@@ -99,12 +106,13 @@ _reg.register_injective_schedule("raf.op.tvm.nll_loss")
 def nllloss_dpred_compute(attr, inputs, output_type):  # pylint: disable=unused-argument
     dy, true, pred = inputs
     n, c = pred.shape
-    dpred = _tvm.te.compute(
-        (n, c),
-        lambda x, y: _tvm.tir.if_then_else(
-            y == true[x], -dy / n if len(dy.shape) == 0 else -dy[0] / n, _tvm.tir.const(0)
-        ),
-    )
+    dy = dy if dy.ndim == 0 else dy[0]
+
+    if true.ndim == 1:  # one-hot label encoding
+        dpred = _tvm.te.compute((n, c), lambda x, y: _tvm.tir.if_then_else(
+            y == true[x], -dy/n, _tvm.tir.const(0)))
+    else:  # sparse label encoding
+        dpred = _tvm.te.compute((n, c), lambda x, y: -true[x, y] / n) * dy
     return [dpred]
 
 
@@ -113,9 +121,15 @@ _reg.register_broadcast_schedule("raf.op.tvm.nll_loss_dpred")
 
 @register_compute("raf.op.tvm.nll_loss_dtrue")
 def nllloss_dtrue_compute(attr, inputs, output_type):  # pylint: disable=unused-argument
-    dy, _, pred = inputs
+    dy, true, pred = inputs
     n, c = pred.shape
-    return [_tvm.te.compute((n, c), lambda x, y: -pred[x, y] / n) * dy]
+
+    dtrue = _tvm.te.compute((n, c), lambda x, y: -pred[x, y] / n) * dy
+
+    if true.ndim == 1:  # for one_hot label encoding
+        dtrue = _topi.sum(dtrue, axis=[1], keepdims=False)
+
+    return [dtrue]
 
 
 _reg.register_broadcast_schedule("raf.op.tvm.nll_loss_dtrue")

--- a/tests/python/op/tvm/test_tvm_loss.py
+++ b/tests/python/op/tvm/test_tvm_loss.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# pylint: disable=too-many-locals
 import numpy as np
 import pytest
 import torch

--- a/tests/python/op/tvm/test_tvm_loss.py
+++ b/tests/python/op/tvm/test_tvm_loss.py
@@ -56,7 +56,8 @@ def test_smooth_l1_loss(device, shape):
 @pytest.mark.parametrize("device", get_testable_devices())
 @pytest.mark.parametrize("n", [3, 7])
 @pytest.mark.parametrize("c", [2, 6])
-def test_nll_loss(device, n, c):
+@pytest.mark.parametrize("one_hot_label", [True, False])
+def test_nll_loss(device, n, c, one_hot_label):
     class TestModel(raf.Model):
         def build(self):
             pass
@@ -68,6 +69,11 @@ def test_nll_loss(device, n, c):
     model = TestModel()
     m_pred, t_pred = randn_torch((n, c), device=device, requires_grad=True)
     m_true, np_true = randint((n,), low=0, high=c, device=device, dtype="int64")
+    if not one_hot_label:
+        m_true = np.zeros((n, c), dtype="float32")
+        for i in range(n):
+            m_true[i, np_true[i]] = 1
+        m_true = raf.array(m_true, device=device)
     t_true = torch.tensor(np_true, device=device)
     # forward
     t_loss = F.nll_loss(t_pred, t_true)


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This is a compatible change for supporting both one-hot label and a 2-dim label for nll_loss, to be consistent with the internal repository.

## Checklist ##

- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @comaniac @hzfan @zachzzc 
