### PR TITLE
[Op] Reduce_Scatter with single tensor as input

### DIFF
--- a/python/raf/distributed/op.py
+++ b/python/raf/distributed/op.py
@@ -131,7 +131,7 @@ def reduce_scatter(x, computation="sum", rank_list=None):
 
     Parameters
     ----------
-    x : List[Tensor]
+    x : Tensor or List[Tensor]
         A list of tensors of equal shape
         replica i receives reduction of x[i] over all replicas
     computation: string
@@ -151,6 +151,8 @@ def reduce_scatter(x, computation="sum", rank_list=None):
         reduction result of x[rank] over all replicas,
         where rank represents rank number of the current process
     """
+    if isinstance(x, (tuple, list)):
+        x = sym.concatenate(x, axis=0)
     return sym._reduce_scatter(x, computation, rank_list=rank_list)
 
 

--- a/scripts/src_codegen/def_schema.py
+++ b/scripts/src_codegen/def_schema.py
@@ -723,7 +723,7 @@ SCHEMAS = {
         ),
     ],
     "communication.h::reduce_scatter": [
-        Arg(name="x", cxx_type="value::BaseTensorValue", cxx_normalizer="TensorTuple"),
+        Arg(name="x", cxx_type="value::BaseTensorValue"),
         Arg(name="computation", cxx_type="std::string", cxx_default='"sum"', py_default='"sum"'),
         Arg(name="rank_list", cxx_type="value::Value", cxx_default="nullptr"),
     ],

--- a/scripts/src_codegen/def_schema.py
+++ b/scripts/src_codegen/def_schema.py
@@ -723,7 +723,7 @@ SCHEMAS = {
         ),
     ],
     "communication.h::reduce_scatter": [
-        Arg(name="x", cxx_type="std::vector<value::BaseTensorValue>", cxx_normalizer="TensorTuple"),
+        Arg(name="x", cxx_type="value::BaseTensorValue", cxx_normalizer="TensorTuple"),
         Arg(name="computation", cxx_type="std::string", cxx_default='"sum"', py_default='"sum"'),
         Arg(name="rank_list", cxx_type="value::Value", cxx_default="nullptr"),
     ],

--- a/src/op/declare/collective_comm.cc
+++ b/src/op/declare/collective_comm.cc
@@ -124,20 +124,13 @@ RAF_OP_DECLARE("raf.op._group_allgather", GroupAllGather)
 void ReduceScatter(const CallValues& call) {
   const auto* args = call->args.as<ReduceScatterArgs>();
   CHECK(args != nullptr);
-  std::vector<BaseTensorValue> tvs = args->x;
+  BaseTensorValue tvs = args->x;
   CHECK_GE(tvs.size(), 1U);
-  const DLTensor* x = tvs[0];
+  const DLTensor* x = tvs;
   std::vector<int64_t> shape(x->shape, x->shape + x->ndim);
-  if (tvs.size() == 1) {
-    int size = GetGlobalCommunicator()->size;
-    CHECK(shape[0] % size == 0);
-    shape[0] = shape[0] / size;
-  } else {
-    for (const auto& tv : tvs) {
-      const DLTensor* x = tv;
-      CHECK(shape == std::vector<int64_t>(x->shape, x->shape + x->ndim));
-    }
-  }
+  int size = GetGlobalCommunicator()->size;
+  CHECK(shape[0] % size == 0);
+  shape[0] = shape[0] / size;
   call->device = x->device;
   call->out = TensorValue::Assemble(/*ctx=*/x->device,
                                     /*dtype=*/x->dtype,

--- a/src/op/declare/collective_comm.cc
+++ b/src/op/declare/collective_comm.cc
@@ -124,9 +124,7 @@ RAF_OP_DECLARE("raf.op._group_allgather", GroupAllGather)
 void ReduceScatter(const CallValues& call) {
   const auto* args = call->args.as<ReduceScatterArgs>();
   CHECK(args != nullptr);
-  BaseTensorValue tvs = args->x;
-  CHECK_GE(tvs.size(), 1U);
-  const DLTensor* x = tvs;
+  const DLTensor* x = args->x;
   std::vector<int64_t> shape(x->shape, x->shape + x->ndim);
   int size = GetGlobalCommunicator()->size;
   CHECK(shape[0] % size == 0);

--- a/src/op/declare/collective_comm.cc
+++ b/src/op/declare/collective_comm.cc
@@ -129,10 +129,12 @@ void ReduceScatter(const CallValues& call) {
   int size = 0;
   if (args->rank_list.defined()) {
     int rank = GetGlobalCommunicator()->rank;
-    for (int i = 0; i < args->rank_list.size(); ++i) {
-      for (int j = 0; j < args->rank_list[i].size(); ++j) {
+    int group_num = Communicator::Get("void", args->rank_list)->size;
+    for (int i = 0; i < group_num; ++i) {
+      int group_size = Communicator::Get("void", args->rank_list[i])->size;
+      for (int j = 0; j < group_size; ++j) {
         if (args->rank_list[i][j] == rank) {
-          size = args->rank_list[i].size();
+          size = group_size;
           break;
         }
       }

--- a/src/op/dialect/nccl/nccl.cc
+++ b/src/op/dialect/nccl/nccl.cc
@@ -251,7 +251,6 @@ RAF_REGISTER_DIALECT_OP(nccl, _group_allgather, 10);
 RAF_OP_ENV_MAKER("raf.op.nccl._group_allgather", NCCLGroupAllGather::make);
 
 class NCCLReduceScatter : public NCCLOpEnv {
-  void* in_buffer;
   size_t size_in_bytes;
   size_t size;
   ncclRedOp_t compute;
@@ -281,10 +280,6 @@ class NCCLReduceScatter : public NCCLOpEnv {
       LOG(FATAL) << "Invalid computation " << args->computation;
     }
 
-    const DLTensor* out = cv->out;
-    size_in_bytes = BytesCompactTensor(*out);
-    size = size_in_bytes / (out->dtype.bits / 8);
-    RequestWorkspace(&in_buffer, cv->device, size_in_bytes * GetGlobalCommunicator()->size);
   }
 
  public:

--- a/src/op/dialect/nccl/nccl.cc
+++ b/src/op/dialect/nccl/nccl.cc
@@ -297,7 +297,7 @@ class NCCLReduceScatter : public NCCLOpEnv {
 
   void Execute(const CallValues& cv) {
     auto args = cv->args.as<raf::op::schema::ReduceScatterArgs>();
-    Execute({TupleValue::make(ir::Array<Value>(args->x.begin(), args->x.end()))}, cv->out);
+    Execute({args->x}, cv->out);
   }
 
   void Execute(const std::vector<value::Value>& inputs, value::Value output) {

--- a/tests/python/distributed/test_collective_communication.py
+++ b/tests/python/distributed/test_collective_communication.py
@@ -282,7 +282,7 @@ def test_allgather_with_subcomm(axis, rank_list):
 
 @pytest.mark.skipif(skip_dist_test(min_rank_num=2, require_exact_rank=True), reason=SKIP_REASON)
 @pytest.mark.parametrize("computation", ["sum", "prod", "min", "max"])
-def test_reduce_scatter_input_tensor_list(computation):
+def test_reduce_scatter_tensor_list(computation):
     class TestModel(raf.Model):
         def build(self):
             pass
@@ -333,65 +333,6 @@ def test_reduce_scatter_input_tensor_list(computation):
             n_out = -n_ones * sum(range(1, total_rank + 1))
             n_out = n_out / total_rank
         check(m_out, n_out)
-
-
-@pytest.mark.skipif(skip_dist_test(min_rank_num=2, require_exact_rank=True), reason=SKIP_REASON)
-@pytest.mark.parametrize("computation", ["sum", "prod", "min", "max"])
-def test_reduce_scatter_input_single_tensor(computation):
-    class TestModel(raf.Model):
-        def build(self):
-            pass
-
-        @raf.model.trace
-        def forward(self, x):
-            x = Symbol.make_tuple([x])
-            out = raf.reduce_scatter(x, computation=computation)
-            return out
-
-    if computation == "avg" and raf.build.with_nccl() < 21000:
-        pytest.skip("avg is not supported in NCCL < 2.10")
-
-    model = TestModel()
-    total_rank, rank, local_rank = get_dist_comm_info(verbose=True)
-    device = f"cuda({local_rank})"
-    n_ones = np.ones(shape=(4, 4), dtype="float32")
-    n_x = n_ones * (rank + 1)
-    n_y = -n_ones * (rank + 1)
-    n_inp = np.concatenate([n_x, n_y])
-    m_inp = raf.array(n_inp, device=device)
-    model.to(device=device)
-    m_out = run_model(model, [m_inp], device)
-    if rank == 0:
-        if computation == "sum":
-            n_out = n_ones * sum(range(1, total_rank + 1))
-        elif computation == "prod":
-            n_out = n_ones * np.prod(range(1, total_rank + 1))
-        elif computation == "min":
-            n_out = n_ones * min(1, total_rank)
-        elif computation == "max":
-            n_out = n_ones * max(1, total_rank)
-        elif computation == "avg":
-            n_out = n_ones * sum(range(1, total_rank + 1))
-            n_out = n_out / total_rank
-        else:
-            assert False, "Invalid computation"
-    elif rank == 1:
-        if computation == "sum":
-            n_out = -n_ones * sum(range(1, total_rank + 1))
-        elif computation == "prod":
-            n_out = n_ones * np.prod(range(1, total_rank + 1))
-        elif computation == "min":
-            n_out = -n_ones * max(1, total_rank)
-        elif computation == "max":
-            n_out = -n_ones * min(1, total_rank)
-        elif computation == "avg":
-            n_out = -n_ones * sum(range(1, total_rank + 1))
-            n_out = n_out / total_rank
-    print("Target output:")
-    print(n_out)
-    print("Ground truth:")
-    print(m_out)
-    check(m_out, n_out)
 
 
 @pytest.mark.skipif(skip_dist_test(min_rank_num=4, require_exact_rank=True), reason=SKIP_REASON)

--- a/tests/python/distributed/test_collective_communication.py
+++ b/tests/python/distributed/test_collective_communication.py
@@ -289,8 +289,7 @@ def test_reduce_scatter_tensor_list(computation):
 
         @raf.model.trace
         def forward(self, x, y):
-            z = Symbol.make_tuple([x, y])
-            out = raf.reduce_scatter(z, computation=computation)
+            out = raf.reduce_scatter([x, y], computation=computation)
             return out
 
     if computation == "avg" and raf.build.with_nccl() < 21000:

--- a/tests/python/distributed/test_collective_communication.py
+++ b/tests/python/distributed/test_collective_communication.py
@@ -344,6 +344,7 @@ def test_reduce_scatter_input_single_tensor(computation):
 
         @raf.model.trace
         def forward(self, x):
+            x = Symbol.make_tuple([x])
             out = raf.reduce_scatter(x, computation=computation)
             return out
 

--- a/tests/python/distributed/test_collective_communication.py
+++ b/tests/python/distributed/test_collective_communication.py
@@ -662,8 +662,7 @@ def test_reduce_scatter_single_tensor(computation):
 
         @raf.model.trace
         def forward(self, x):
-            z = Symbol.make_tuple([x])
-            out = raf.reduce_scatter(z, computation=computation)
+            out = raf.reduce_scatter(x, computation=computation)
             return out
 
     if computation == "avg" and raf.build.with_nccl() < 21000:

--- a/tests/python/distributed/test_collective_communication.py
+++ b/tests/python/distributed/test_collective_communication.py
@@ -282,7 +282,7 @@ def test_allgather_with_subcomm(axis, rank_list):
 
 @pytest.mark.skipif(skip_dist_test(min_rank_num=2, require_exact_rank=True), reason=SKIP_REASON)
 @pytest.mark.parametrize("computation", ["sum", "prod", "min", "max"])
-def test_reduce_scatter(computation):
+def test_reduce_scatter_input_tensor_list(computation):
     class TestModel(raf.Model):
         def build(self):
             pass
@@ -333,6 +333,60 @@ def test_reduce_scatter(computation):
             n_out = -n_ones * sum(range(1, total_rank + 1))
             n_out = n_out / total_rank
         check(m_out, n_out)
+
+
+@pytest.mark.skipif(skip_dist_test(min_rank_num=2, require_exact_rank=True), reason=SKIP_REASON)
+@pytest.mark.parametrize("computation", ["sum", "prod", "min", "max"])
+def test_reduce_scatter_input_single_tensor(computation):
+    class TestModel(raf.Model):
+        def build(self):
+            pass
+
+        @raf.model.trace
+        def forward(self, x):
+            out = raf.reduce_scatter(x, computation=computation)
+            return out
+
+    if computation == "avg" and raf.build.with_nccl() < 21000:
+        pytest.skip("avg is not supported in NCCL < 2.10")
+
+    model = TestModel()
+    total_rank, rank, local_rank = get_dist_comm_info(verbose=True)
+    device = f"cuda({local_rank})"
+    n_ones = np.ones(shape=(4, 4), dtype="float32")
+    n_x = n_ones * (rank + 1)
+    n_y = -n_ones * (rank + 1)
+    n_inp = np.concatenate([n_x, n_y])
+    m_inp = raf.array(n_inp, device=device)
+    model.to(device=device)
+    m_out = run_model(model, m_inp, device)
+    if rank == 0:
+        if computation == "sum":
+            n_out = n_ones * sum(range(1, total_rank + 1))
+        elif computation == "prod":
+            n_out = n_ones * np.prod(range(1, total_rank + 1))
+        elif computation == "min":
+            n_out = n_ones * min(1, total_rank)
+        elif computation == "max":
+            n_out = n_ones * max(1, total_rank)
+        elif computation == "avg":
+            n_out = n_ones * sum(range(1, total_rank + 1))
+            n_out = n_out / total_rank
+        else:
+            assert False, "Invalid computation"
+    elif rank == 1:
+        if computation == "sum":
+            n_out = -n_ones * sum(range(1, total_rank + 1))
+        elif computation == "prod":
+            n_out = n_ones * np.prod(range(1, total_rank + 1))
+        elif computation == "min":
+            n_out = -n_ones * max(1, total_rank)
+        elif computation == "max":
+            n_out = -n_ones * min(1, total_rank)
+        elif computation == "avg":
+            n_out = -n_ones * sum(range(1, total_rank + 1))
+            n_out = n_out / total_rank
+    check(m_out, n_out)
 
 
 @pytest.mark.skipif(skip_dist_test(min_rank_num=4, require_exact_rank=True), reason=SKIP_REASON)

--- a/tests/python/distributed/test_collective_communication.py
+++ b/tests/python/distributed/test_collective_communication.py
@@ -386,6 +386,10 @@ def test_reduce_scatter_input_single_tensor(computation):
         elif computation == "avg":
             n_out = -n_ones * sum(range(1, total_rank + 1))
             n_out = n_out / total_rank
+    print("Target output:")
+    print(n_out)
+    print("Ground truth:")
+    print(m_out)
     check(m_out, n_out)
 
 

--- a/tests/python/distributed/test_collective_communication.py
+++ b/tests/python/distributed/test_collective_communication.py
@@ -359,7 +359,7 @@ def test_reduce_scatter_input_single_tensor(computation):
     n_inp = np.concatenate([n_x, n_y])
     m_inp = raf.array(n_inp, device=device)
     model.to(device=device)
-    m_out = run_model(model, m_inp, device)
+    m_out = run_model(model, [m_inp], device)
     if rank == 0:
         if computation == "sum":
             n_out = n_ones * sum(range(1, total_rank + 1))

--- a/tests/python/distributed/test_collective_communication.py
+++ b/tests/python/distributed/test_collective_communication.py
@@ -344,8 +344,7 @@ def test_reduce_scatter_with_rank_list(computation, rank_list):
 
         @raf.model.trace
         def forward(self, x, y):
-            z = Symbol.make_tuple([x, y])
-            out = raf.reduce_scatter(z, computation=computation, rank_list=rank_list)
+            out = raf.reduce_scatter([x, y], computation=computation, rank_list=rank_list)
             return out
 
     if computation == "avg" and raf.build.with_nccl() < 21000:


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR enables reduce_scatter to receive single tensor as input. For input tensor list, reduce scatter concatenates it into a single tensor first.

## Checklist ##

- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @awslabs/raf-reviewer
