### PR TITLE
[Bugfix] Use int64_t for memory budget

### DIFF
--- a/src/pass/rematerialization.cc
+++ b/src/pass/rematerialization.cc
@@ -1001,7 +1001,7 @@ TVM_REGISTER_PASS_CONFIG_OPTION("raf.remat.use_gflops_cost", IntImm);
 
 Pass Rematerialization() {
   PassContext pass_ctx = PassContext::Current();
-  int memory_budget =
+  int64_t memory_budget =
       pass_ctx->GetConfig("raf.memory_budget", Integer(static_cast<int>(0))).value().IntValue();
   // Turn profiler on by default. With caching it is pretty fast now.
   bool use_profiler = !(pass_ctx->GetConfig("raf.remat.use_gflops_cost", Bool(false)).value());


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
In #96, I placed a wrong data type for memory budget which results in overflow.

## Checklist ##

- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @awslabs/raf-reviewer
