### PR TITLE
[CUDA] Support multiple CUDA archs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,8 +114,15 @@ else ()
   enable_language(CUDA)
   set(CMAKE_CUDA_ARCHITECTURES ${RAF_CUDA_ARCH})
   set(RAF_CXX_FLAGS ${RAF_CXX_FLAGS} -DRAF_USE_CUDA)
-  set(RAF_CUDA_FLAGS ${RAF_CUDA_FLAGS} -DRAF_USE_CUDA
-      -gencode=arch=compute_${RAF_CUDA_ARCH},code=sm_${RAF_CUDA_ARCH})
+
+  set(RAF_CUDA_FLAGS ${RAF_CUDA_FLAGS} -DRAF_USE_CUDA)
+  foreach(ARCH ${RAF_CUDA_ARCH_LIST})
+    set(CODES)
+    list(APPEND CODES sm_${ARCH})
+    list(APPEND CODES compute_${ARCH})
+    list(JOIN CODES "," CODES_STR)
+    list(APPEND RAF_CUDA_ARCH_LIST -gencode=arch=compute_${ARCH},code=[${CODES_STR}])
+  endforeach()
 
   file(GLOB_RECURSE RAF_CUDA_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/src/device_api/cuda/*.cc


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
With this PR, we now support `set(RAF_CUDA_ARCH 70;75)` in config.cmake. This variable will affect both RAF CUDA kernels and CUTLASS kernels so that the compiled PTX could support multiple CUDA platforms.

## Checklist ##

- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @awslabs/raf-reviewer @zhen-jia @hzfan @yzhliu 
