### PR TITLE
[Op] Make up in_states arg of dropout in from_relay

### DIFF
--- a/src/op/from_relay/nn.cc
+++ b/src/op/from_relay/nn.cc
@@ -202,6 +202,8 @@ RAF_OP_FROM_RELAY("nn.dropout", "raf.op._contrib_dropout",
                     Array<Expr> raf_args = args;
                     const auto* relay_attrs = attrs.as<DropoutAttrs>();
                     raf_args.push_back(MakeConstant(ScalarValue::make(relay_attrs->rate)));
+                    // We make up a NULL in_states argument which is required by raf but not pytorch
+                    raf_args.push_back(MakeNull());
                     return raf_args;
                   });
 

--- a/tests/python/pass/test_pass_from_relay.py
+++ b/tests/python/pass/test_pass_from_relay.py
@@ -854,7 +854,6 @@ def test_raf_conv2d_trans(xshape, wshape, stride_output_padding, dilation, paddi
 
 
 # FIXME(@XIAO-XIA): Re-enable once dropout/dropout_dx can be dispatched to CuDNN.
-@pytest.mark.xfail
 @pytest.mark.parametrize("device", get_testable_devices())
 @pytest.mark.parametrize("shape", [(8, 3, 32, 32)])
 @pytest.mark.parametrize("p", [0.3, 0.7])


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
The dropout op in RAF requires an extra "in_states" argument compared to it in PyTorch. So we make up a NULL in_states argument in from_relay.

## Checklist ##

- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @awslabs/raf-reviewer
