### PR TITLE
[CI] Update action deprecating save-output cmd

### DIFF
--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           bash ./scripts/lint/git-skip-testing.sh
           SKIP_CI=$(bash ./scripts/lint/git-skip-testing.sh)
-          echo "::set-output name=skip_ci::${SKIP_CI}"
+          echo "skip_ci=${SKIP_CI} >> $GITHUB_OUTPUT"
       - name: Save common job info
         # Initialize the artifact and whether to skip CI.
         run: |

--- a/.github/workflows/ci_unit_test.yml
+++ b/.github/workflows/ci_unit_test.yml
@@ -43,11 +43,11 @@ jobs:
         id: job_info
         run: |
           skip_ci=$(head -n 1 artifact/skip.txt)
-          echo "::set-output name=skip_ci::${skip_ci}"
+          echo "skip_ci=${skip_ci} >> $GITHUB_OUTPUT"
           ref=$(head -n 1 artifact/ref.txt)
-          echo "::set-output name=ref::${ref}"
+          echo "ref=${ref} >> $GITHUB_OUTPUT"
           repo=$(head -n 1 artifact/repo.txt)
-          echo "::set-output name=repo::${repo}"
+          echo "repo=${repo} >> $GITHUB_OUTPUT"
           lint=${{ github.event.workflow_run.conclusion }}
           echo "Linting result: ${lint}"
       - name: Parse PR job info
@@ -56,16 +56,16 @@ jobs:
         # Note that pr and sha only available for pull request, and will be empty for push events.
         run: |
           pr=$(head -n 1 artifact/pr.txt)
-          echo "::set-output name=pr::${pr}"
+          echo "pr=${pr} >> $GITHUB_OUTPUT"
           sha=$(head -n 1 artifact/sha.txt)
-          echo "::set-output name=sha::${sha}"
+          echo "sha=${sha} >> $GITHUB_OUTPUT"
       - name: Generate tag
         id: gen_tag
         # This tag is PR-unique so it can be used to connect jobs for the same PR.
         # For example, we use it to share ccache caches and cancel previous runs.
         run: |
           tag=${{ steps.job_info.outputs.repo }}/${{ steps.pr_job_info.outputs.pr }}
-          echo "::set-output name=tag::${tag}"
+          echo "tag=${tag} >> $GITHUB_OUTPUT"
       - name: Whether linting was failed
         if: ${{ github.event.workflow_run.conclusion != 'success' }}
         run: exit 1
@@ -229,7 +229,7 @@ jobs:
         # Note that pr and sha only available for pull request, and will be empty for push events.
         run: |
           pr=$(head -n 1 artifact/pr.txt)
-          echo "::set-output name=pr::${pr}"       
+          echo "pr=${pr} >> $GITHUB_OUTPUT"
       - name: Generate CI badge
         id: badge
         run: |
@@ -238,16 +238,16 @@ jobs:
             echo "No need to update badge for PR CI. Skip."
             exit 0
           fi
-          echo "::set-output name=gist_id::a3f4a76704e40ddba1b73fb0ad072eb9"
+          echo "gist_id=a3f4a76704e40ddba1b73fb0ad072eb9 >> $GITHUB_OUTPUT"
           head_commit=$(git rev-parse --short HEAD)
           if [[ "${{ needs.test_on_cpu.result }}" == "success" &&
                 "${{ needs.test_on_gpu.result }}" == "success" &&
                 "${{ needs.test_on_multi_gpu.result }}" == "success" ]]; then
-            echo "::set-output name=message::passing (${head_commit})"
-            echo "::set-output name=color::success"
+            echo "message=passing (${head_commit}) >> $GITHUB_OUTPUT"
+            echo "color=success"
           else
-            echo "::set-output name=message::failing (${head_commit})"
-            echo "::set-output name=color::critical"
+            echo "message=failing (${head_commit}) >> $GITHUB_OUTPUT"
+            echo "color=critical >> $GITHUB_OUTPUT"
           fi
       - name: Update CI badge
         # Intentionally fail this step with empty gist_id.

--- a/.github/workflows/update_tvm.yml
+++ b/.github/workflows/update_tvm.yml
@@ -24,7 +24,7 @@ jobs:
         git submodule update --remote 3rdparty/tvm
     - name: Create timestamp
       id: date
-      run: echo "::set-output name=now::$(date +'%Y-%m-%d-%H-%M-%S')"
+      run: echo "now=$(date +'%Y-%m-%d-%H-%M-%S') >> $GITHUB_OUTPUT"
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
       with:


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##

Github Action changelog:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

In short, `save-output` command is deprecating, so this PR changes them to use environment files accordingly.

## Checklist ##

- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

cc @awslabs/raf-reviewer
