### PR TITLE
[Compatible] Fix batch_matmul from Relay

### DIFF
--- a/src/op/from_relay/nn.cc
+++ b/src/op/from_relay/nn.cc
@@ -34,9 +34,8 @@ RELAY_REGISTER_OP("nn.batch_matmul")
         return Call(Op::Get("raf.op.batch_matmul_tn"), args);
       } else if (!transpose_a && transpose_b) {
         return Call(Op::Get("raf.op.batch_matmul_nt"), args);
-      } else {
-        return Call(Op::Get("raf.op.batch_matmul"), args);
       }
+      return Call(Op::Get("raf.op.batch_matmul"), args);
     });
 
 RAF_OP_FROM_RELAY("nn.conv2d", "raf.op.conv2d",

--- a/src/op/from_relay/nn.cc
+++ b/src/op/from_relay/nn.cc
@@ -15,8 +15,29 @@ namespace raf {
 namespace op {
 namespace from_relay {
 
-RAF_GENERIC_ATTR_OP_FROM_RELAY("nn.batch_matmul", "raf.op.batch_matmul_nt");
 RAF_GENERIC_ATTR_OP_FROM_RELAY("nn.dense", "raf.op.dense");
+
+// TVM's nn.batch_matmul has a transpose_a and transpose_b attribute, but RAF's
+// batch_matmul_nt does not. Instead, RAF has 4 variants of batch_matmul for
+// different combinations of transpose_a and transpose_b. This function
+// converts the batch_matmul with transpose_a and transpose_b attributes to
+// the appropriate batch_matmul variant.
+RELAY_REGISTER_OP("nn.batch_matmul")
+    .set_attr<op::FRAFFromRelay>("FRAFFromRelay", [](const Attrs& attrs, const Array<Expr>& args,
+                                                     const VarValueMap& val_map) {
+      const auto* relay_attrs = attrs.as<BatchMatmulAttrs>();
+      auto transpose_a = relay_attrs->transpose_a;
+      auto transpose_b = relay_attrs->transpose_b;
+      if (transpose_a && transpose_b) {
+        return Call(Op::Get("raf.op.batch_matmul_tt"), args);
+      } else if (transpose_a && !transpose_b) {
+        return Call(Op::Get("raf.op.batch_matmul_tn"), args);
+      } else if (!transpose_a && transpose_b) {
+        return Call(Op::Get("raf.op.batch_matmul_nt"), args);
+      } else {
+        return Call(Op::Get("raf.op.batch_matmul"), args);
+      }
+    });
 
 RAF_OP_FROM_RELAY("nn.conv2d", "raf.op.conv2d",
                   [&](const Attrs& attrs, const Array<Expr>& args, const VarValueMap& val_map) {

--- a/tests/python/pass/test_pass_from_relay.py
+++ b/tests/python/pass/test_pass_from_relay.py
@@ -1120,7 +1120,7 @@ def test_gelu_pattern(shape, dtype, device):
     bias = raf.ir.var("bias", shape=shape, dtype=dtype)
 
     a0 = _relay.add(r_x, bias)
-    a1 = _relay.multiply(a0, _relay.const(1 / 2**0.5, dtype))
+    a1 = _relay.multiply(a0, _relay.const(1 / 2 ** 0.5, dtype))
     a2 = _relay.erf(a1)
     a3 = _relay.multiply(a2, _relay.const(0.5, dtype))
     a4 = _relay.add(_relay.const(0.5, dtype), a3)


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
https://github.com/apache/tvm/pull/13927 changes the logic of converting PyTorch batch_matmul to Relay. Specifically, it uses Relay's batch_matmul attribute `transpose_b` to avoid explicitly adding a transpose op. However, the current logic of converting Relay to RAF doesn't consider this attribute and results in incorrect IRs.

This PR thus fixes the Relay to RAF conversion logic to dispatch Relay batch_matmul to one of batch_matmul_xy ops.

## Checklist ##

- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @awslabs/raf-reviewer
